### PR TITLE
feat: keystore support large stdin secrets (>1024 bytes) and multiline

### DIFF
--- a/core/keystore/cmd.go
+++ b/core/keystore/cmd.go
@@ -120,7 +120,7 @@ func addKeystoreValue(args []string) error {
 	if *stdin {
 		keyValue, err = io.ReadAll(os.Stdin)
 		if err != nil {
-			return fmt.Errorf("could not read input from stdin")
+			return fmt.Errorf("could not read input from stdin: %w", err)
 		}
 		// Trim a single trailing newline (common when piping from echo),
 		// but preserve embedded newlines in the value.

--- a/core/keystore/cmd.go
+++ b/core/keystore/cmd.go
@@ -28,12 +28,13 @@
 package keystore
 
 import (
-	"bufio"
+	"bytes"
 	"flag"
 	"fmt"
 	"golang.org/x/crypto/ssh/terminal"
 	"infini.sh/framework/core/util"
 	kslib "infini.sh/framework/lib/keystore"
+	"io"
 	"os"
 	"strings"
 	"syscall"
@@ -84,7 +85,17 @@ func addKeystoreValue(args []string) error {
 		stdin = addFlag.Bool("stdin", false, "Use the stdin as the source of the secret")
 		force = addFlag.Bool("force", false, "Override the existing key")
 	)
-	err := addFlag.Parse(args)
+	// Reorder args so flags come before positional arguments,
+	// allowing usage like: keystore add MY_KEY --stdin --force
+	var flagArgs, posArgs []string
+	for _, a := range args {
+		if strings.HasPrefix(a, "-") {
+			flagArgs = append(flagArgs, a)
+		} else {
+			posArgs = append(posArgs, a)
+		}
+	}
+	err := addFlag.Parse(append(flagArgs, posArgs...))
 	if err != nil {
 		return err
 	}
@@ -107,14 +118,17 @@ func addKeystoreValue(args []string) error {
 
 	var keyValue []byte
 	if *stdin {
-		reader := bufio.NewReader(os.Stdin)
-		keyValue, _, err = reader.ReadLine()
+		keyValue, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			return fmt.Errorf("could not read input from stdin")
 		}
+		// Trim a single trailing newline (common when piping from echo),
+		// but preserve embedded newlines in the value.
+		keyValue = bytes.TrimRight(keyValue, "\r\n")
 	} else {
 		fmt.Printf("Enter value for %s: ", key)
 		keyValue, err = terminal.ReadPassword(int(syscall.Stdin))
+		fmt.Println()
 		if err != nil {
 			return fmt.Errorf("could not read value from the input, error: %s\n", err)
 		}

--- a/docs/content.en/docs/references/keystore.md
+++ b/docs/content.en/docs/references/keystore.md
@@ -1,0 +1,163 @@
+---
+title: "Keystore"
+weight: 60
+---
+
+# Keystore
+
+The INFINI Framework provides a secure keystore for managing sensitive configuration values such as passwords, API keys, certificates, and other secrets. Secrets are stored in an AES-256 encrypted file on disk and can be referenced in configuration files using variable substitution.
+
+## Overview
+
+The keystore offers three ways to manage secrets:
+
+- **CLI Commands**: Add, list, and remove secrets from the command line.
+- **REST API**: Set secrets programmatically via HTTP.
+- **Configuration Reference**: Use `$[[keystore.<key>]]` syntax to inject secrets into YAML configuration files.
+
+Secrets are stored under the application's data directory in a `.keystore/` folder containing an encrypted store file (`ks`) and an auto-generated encryption key (`key`).
+
+## CLI Commands
+
+The keystore CLI is accessed via the `keystore` subcommand of your application binary.
+
+### Usage
+
+```shell
+<app> keystore <command> [<args>]
+```
+
+### Available Commands
+
+| Command  | Description                   |
+|----------|-------------------------------|
+| `add`    | Add or update a secret        |
+| `list`   | List all secret keys          |
+| `remove` | Remove a secret by key        |
+
+### Adding a Secret
+
+#### Interactive Mode
+
+When run without `--stdin`, the command prompts for the secret value with hidden input (no echo):
+
+```shell
+<app> keystore add my_password
+Enter value for my_password:
+success
+```
+
+> **Note:** Interactive mode uses the terminal's canonical input, which is limited to approximately 1024 bytes by the operating system. For larger values or values containing newlines, use `--stdin` mode instead.
+
+#### Stdin Mode
+
+Use `--stdin` to pipe a value from standard input. This mode supports **arbitrary length** values and **multi-line** content (e.g., certificates, private keys):
+
+```shell
+# From a simple string
+echo -n "my_secret_value" | <app> keystore add my_key --stdin
+
+# From a file (preserves newlines)
+cat /path/to/cert.pem | <app> keystore add tls_cert --stdin
+
+# Using a heredoc
+<app> keystore add my_key --stdin <<EOF
+line1
+line2
+line3
+EOF
+```
+
+Trailing `\r\n` or `\n` characters are automatically trimmed, but embedded newlines within the value are preserved.
+
+#### Flags
+
+| Flag       | Description                                            |
+|------------|--------------------------------------------------------|
+| `--stdin`  | Read the secret value from standard input instead of the terminal prompt |
+| `--force`  | Overwrite an existing key without prompting for confirmation |
+
+#### Overwriting an Existing Secret
+
+In interactive mode, you will be prompted to confirm the overwrite:
+
+```shell
+<app> keystore add my_password
+Secret my_password already exists, Overwrite? [y/N]: y
+Enter value for my_password:
+success
+```
+
+With `--stdin`, use `--force` to overwrite without confirmation:
+
+```shell
+echo -n "new_value" | <app> keystore add my_password --stdin --force
+```
+
+### Listing Secrets
+
+List all keys stored in the keystore:
+
+```shell
+<app> keystore list
+```
+
+Example output:
+
+```
+my_password
+tls_cert
+api_key
+```
+
+Only key names are displayed; secret values are never printed.
+
+### Removing a Secret
+
+Remove a secret by its key name:
+
+```shell
+<app> keystore remove my_password
+```
+
+## Using Secrets in Configuration
+
+Secrets stored in the keystore can be referenced in YAML configuration files using the `$[[keystore.<key>]]` variable syntax:
+
+```yaml
+elasticsearch:
+  - name: production
+    endpoint: https://localhost:9200
+    basic_auth:
+      username: admin
+      password: $[[keystore.my_password]]
+```
+
+When the configuration is loaded, `$[[keystore.my_password]]` is resolved to the secret value stored under the key `my_password`.
+
+## Storage Location
+
+By default, the keystore is stored in the application's data directory:
+
+```
+<data_dir>/.keystore/
+├── key    # Auto-generated AES encryption key
+└── ks     # Encrypted secrets store
+```
+
+### Custom Path
+
+Set the `KEYSTORE_PATH` environment variable to override the storage location:
+
+```shell
+export KEYSTORE_PATH=/secure/path/to/keystore
+<app> keystore add my_key
+```
+
+
+## Security Considerations
+
+- The keystore file is encrypted using **AES-256-GCM** with a key derived via **PBKDF2** (SHA-512, 10,000 iterations).
+- The encryption key file (`key`) is stored with restrictive file permissions (`0600`).
+- Secret values are never logged or printed to the console.
+- The keystore supports file watching — changes are automatically reloaded at runtime.

--- a/docs/content.en/docs/references/keystore.md
+++ b/docs/content.en/docs/references/keystore.md
@@ -12,7 +12,6 @@ The INFINI Framework provides a secure keystore for managing sensitive configura
 The keystore offers three ways to manage secrets:
 
 - **CLI Commands**: Add, list, and remove secrets from the command line.
-- **REST API**: Set secrets programmatically via HTTP.
 - **Configuration Reference**: Use `$[[keystore.<key>]]` syntax to inject secrets into YAML configuration files.
 
 Secrets are stored under the application's data directory in a `.keystore/` folder containing an encrypted store file (`ks`) and an auto-generated encryption key (`key`).

--- a/docs/content.en/docs/references/keystore.md
+++ b/docs/content.en/docs/references/keystore.md
@@ -157,6 +157,6 @@ export KEYSTORE_PATH=/secure/path/to/keystore
 ## Security Considerations
 
 - The keystore file is encrypted using **AES-256-GCM** with a key derived via **PBKDF2** (SHA-512, 10,000 iterations).
-- The encryption key file (`key`) is stored with restrictive file permissions (`0600`).
+- The encryption key file (`key`) should be protected with restrictive file permissions (for example, `0600`).
 - Secret values are never logged or printed to the console.
 - The keystore supports file watching — changes are automatically reloaded at runtime.

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -14,6 +14,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: support team-based scope for sharing services #258
 - feat: add semantic, hybrid, and nested query support #265
 - feat: extract BuildFuzzinessQueryClauses as public API #266
+- feat(keystore): support large stdin secrets (>1024 bytes) and multiline #271
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  


### PR DESCRIPTION
…ne values

## What does this PR do

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [x] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation