### PR TITLE
fix: treat missing config key as exist=false instead of error

### DIFF
--- a/core/env/env.go
+++ b/core/env/env.go
@@ -30,7 +30,6 @@ package env
 import (
 	"compress/gzip"
 	"fmt"
-	"infini.sh/framework/lib/go-ucfg"
 	"io/ioutil"
 	"os"
 	"path"
@@ -45,6 +44,7 @@ import (
 	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/errors"
 	"infini.sh/framework/core/util"
+	"infini.sh/framework/lib/go-ucfg"
 )
 
 //TODO storage adaptor should config in env
@@ -541,27 +541,28 @@ func ParseConfig(configKey string, configInstance interface{}) (exist bool, err 
 }
 
 func ParseConfigSection(cfg *config.Config, configKey string, configInstance interface{}) (exist bool, err error) {
-	if cfg != nil {
-		childConfig, err := cfg.Child(configKey, -1)
-		if err != nil {
-			return exist, err
-		}
-
-		log.Tracef("found config: %s ", configKey)
-
-		exist = true
-
-		err = childConfig.Unpack(configInstance)
-		log.Tracef("parsed config: %s, %v", configKey, configInstance)
-		if err != nil {
-			return exist, err
-		}
-
-		return exist, nil
-	} else {
-		log.Debugf("config: %s not found", configKey)
+	if cfg == nil {
+		return exist, errors.Errorf("cfg is nil")
 	}
-	return exist, errors.Errorf("invalid config: %s", configKey)
+
+	childConfig, err := cfg.Child(configKey, -1)
+	if err != nil {
+		// go-ucfg raises an error if the key does not exist, in which case
+		// we should return and report that the configKey does not exist.
+		if ucfgErr, ok := err.(ucfg.Error); ok && ucfgErr.Reason() == ucfg.ErrMissing {
+			log.Debugf("config key: %s not found", configKey)
+			return false, nil
+		}
+
+		return exist, err
+	}
+
+	log.Tracef("found config key: %s ", configKey)
+	exist = true
+
+	err = childConfig.Unpack(configInstance)
+	log.Tracef("parsed config: %s, %v", configKey, configInstance)
+	return exist, err
 }
 
 func getModuleName(c *config.Config) string {

--- a/core/env/env_test.go
+++ b/core/env/env_test.go
@@ -1,0 +1,118 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Framework is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package env
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"infini.sh/framework/core/config"
+)
+
+func TestParseConfigSection_NilConfig(t *testing.T) {
+	var out struct{ Foo string }
+	exist, err := ParseConfigSection(nil, "anykey", &out)
+
+	assert.False(t, exist)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cfg is nil")
+}
+
+func TestParseConfigSection_MissingKey_ReturnsFalseNil(t *testing.T) {
+	cfg, err := config.NewConfigFrom(map[string]interface{}{
+		"other_section": map[string]interface{}{"a": 1},
+	})
+	require.NoError(t, err)
+
+	var out struct{ Foo string }
+	exist, err := ParseConfigSection(cfg, "nonexistent_key", &out)
+
+	assert.False(t, exist)
+	assert.NoError(t, err, "missing key should return nil error, not ErrMissing")
+}
+
+func TestParseConfigSection_MissingKey_EmptyConfig(t *testing.T) {
+	// Empty config: any key is missing.
+	cfg, err := config.NewConfigFrom(map[string]interface{}{})
+	require.NoError(t, err)
+
+	var out struct{ Foo string }
+	exist, err := ParseConfigSection(cfg, "anykey", &out)
+
+	assert.False(t, exist)
+	assert.NoError(t, err)
+}
+
+func TestParseConfigSection_ExistingKey_UnpackOK(t *testing.T) {
+	cfg, err := config.NewConfigFrom(map[string]interface{}{
+		"mysection": map[string]interface{}{
+			"foo": "bar",
+			"num": 42,
+		},
+	})
+	require.NoError(t, err)
+
+	var out struct {
+		Foo string `config:"foo"`
+		Num int    `config:"num"`
+	}
+	exist, err := ParseConfigSection(cfg, "mysection", &out)
+
+	assert.True(t, exist)
+	assert.NoError(t, err)
+	assert.Equal(t, "bar", out.Foo)
+	assert.Equal(t, 42, out.Num)
+}
+
+func TestParseConfigSection_ExistingKey_UnpackFails(t *testing.T) {
+	cfg, err := config.NewConfigFrom(map[string]interface{}{
+		"mysection": map[string]interface{}{
+			"foo": "not_an_int",
+		},
+	})
+	require.NoError(t, err)
+
+	var out struct {
+		Foo int `config:"foo"`
+	}
+	exist, err := ParseConfigSection(cfg, "mysection", &out)
+
+	assert.True(t, exist)
+	require.Error(t, err)
+}
+
+func TestParseConfigSection_KeyExistsButPrimitive_ReturnsError(t *testing.T) {
+	// Key exists but value is primitive (string), not an object. Child returns type error.
+	cfg, err := config.NewConfigFrom(map[string]interface{}{
+		"mysection": "a_string_value",
+	})
+	require.NoError(t, err)
+
+	var out struct{ Foo string }
+	exist, err := ParseConfigSection(cfg, "mysection", &out)
+
+	assert.False(t, exist)
+	require.Error(t, err)
+}


### PR DESCRIPTION
ParseConfigSection uses cfg.Child() to look up a config key (e.g. "setup"). When the key does not exist, go-ucfg returns ErrMissing ("missing field accessing 'setup'"). The previous implementation returned this error directly to the caller, which is not correct.

This commit fixes the behavior by treating ErrMissing as the config key not existing, instead of returning it as an error.

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [x] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation