### PR TITLE
feat(cors): add X-SERVICE-ID to allowed CORS headers

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -15,6 +15,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add semantic, hybrid, and nested query support #265
 - feat: extract BuildFuzzinessQueryClauses as public API #266
 - feat(keystore): support large stdin secrets (>1024 bytes) and multiline #271
+- feat(cors): add X-SERVICE-ID to allowed CORS headers #275
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  

--- a/modules/security/http_filters/cors.go
+++ b/modules/security/http_filters/cors.go
@@ -5,12 +5,13 @@
 package http_filters
 
 import (
+	"net/http"
+
 	log "github.com/cihub/seelog"
 	"infini.sh/framework/core/api"
 	httprouter "infini.sh/framework/core/api/router"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/security"
-	"net/http"
 )
 
 func init() {
@@ -48,7 +49,7 @@ func (f *CORSFilter) ApplyFilter(
 		if options.Feature(FeatureByPassCORSCheck) || (origin != "" && (r.Method == http.MethodOptions || security.IsAllowedOrigin(origin, r))) {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, DELETE, OPTIONS")
-			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-API-TOKEN, APP-INTEGRATION-ID, WEBSOCKET-SESSION-ID")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-API-TOKEN, X-SERVICE-ID, APP-INTEGRATION-ID, WEBSOCKET-SESSION-ID")
 			if options.Feature(FeatureNotAllowCredentials) {
 				w.Header().Set("Access-Control-Allow-Credentials", "false")
 			} else {


### PR DESCRIPTION
Easysearch UI calls the agent API cross-origin and passes X-SERVICE-ID to indicate which Easysearch service to authenticate against. The agent then uses the forwarded auth header to call GET /_security/account on that service and checks whether the user has the superuser role before allowing the request. Without X-SERVICE-ID in the allowed headers list, the browser CORS preflight would block the header and the request would never reach the agent.


## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation