### PR TITLE
feat(cookie): prevent aggressive session cookie expiration

### DIFF
--- a/core/api/session.go
+++ b/core/api/session.go
@@ -60,7 +60,44 @@ func GetSessionStore(r *http.Request, key string) (*sessions.Session, error) {
 	return getStore().Get(r, key)
 }
 
+const sessionCookiePrefix = "INFINI-SESSION-"
+
+// cookieSizeCleanupThreshold is the Cookie header size (bytes) beyond which
+// foreign session cookies are expired. Below this threshold multiple services
+// on the same host can coexist without interfering with each other's sessions.
+const cookieSizeCleanupThreshold = 6 * 1024
+
+// cleanupForeignSessionCookies expires INFINI-SESSION-* cookies that belong to
+// other services running on the same host (but different ports).
+// Per RFC 6265 cookies are scoped by domain only, not by port, so multiple
+// services on localhost accumulate each other's session cookies and can exceed
+// the 8192-byte header limit.
+//
+// To avoid logging out other services unnecessarily, cleanup only triggers when
+// the total Cookie header approaches the dangerous size limit.
+func cleanupForeignSessionCookies(w http.ResponseWriter, r *http.Request) {
+	cookieHeader := r.Header.Get("Cookie")
+	if len(cookieHeader) < cookieSizeCleanupThreshold {
+		return
+	}
+
+	myName := getSessionName()
+	for _, c := range r.Cookies() {
+		if strings.HasPrefix(c.Name, sessionCookiePrefix) && c.Name != myName {
+			http.SetCookie(w, &http.Cookie{
+				Name:     c.Name,
+				Value:    "",
+				Path:     "/",
+				MaxAge:   -1,
+				HttpOnly: true,
+			})
+		}
+	}
+}
+
 func GetSession(w http.ResponseWriter, r *http.Request, key string) (bool, interface{}) {
+	cleanupForeignSessionCookies(w, r)
+
 	s := getStore()
 	session, err := s.Get(r, getSessionName())
 
@@ -107,6 +144,8 @@ func SetSession(w http.ResponseWriter, r *http.Request, key string, value interf
 }
 
 func ForceSetSession(w http.ResponseWriter, r *http.Request, key string, value interface{}, force bool) bool {
+	cleanupForeignSessionCookies(w, r)
+
 	s := getStore()
 	var (
 		session *sessions.Session
@@ -204,6 +243,7 @@ func DelSession(w http.ResponseWriter, r *http.Request, key string) bool {
 
 // DestroySession remove session by creating a new empty session
 func DestroySession(w http.ResponseWriter, r *http.Request) bool {
+	cleanupForeignSessionCookies(w, r)
 
 	s := getStore()
 	session, err := s.New(r, getSessionName())

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -19,6 +19,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(keystore): support large stdin secrets (>1024 bytes) and multiline #271
 - feat(cors): add X-SERVICE-ID to allowed CORS headers #275
 - feat: output HTTP access logs to file
+- feat(cookie): prevent aggressive session cookie expiration #284
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  


### PR DESCRIPTION
## What does this PR do
Introduce a threshold-based cleanup mechanism for session cookies. Check the Cookie header size first and only trigger cleanup when it exceeds 6 KB, leaving headroom before the 8 KB browser/server limit. This ensures that:

- 2–3 services on localhost: cookies coexist fine, all sessions survive, no logout
- Many services / cookie bloat: cleanup kicks in to prevent the 8192-byte overflow, expiring foreign session cookies as a last resort

The tradeoff is intentional — you only lose foreign sessions when the alternative would be broken requests from header overflow.
## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation