### PR TITLE
fix: handle string elasticsearch search errors

### DIFF
--- a/core/elastic/index.go
+++ b/core/elastic/index.go
@@ -24,6 +24,7 @@
 package elastic
 
 import (
+	"bytes"
 	"errors"
 	"github.com/buger/jsonparser"
 	"github.com/segmentio/encoding/json"
@@ -233,6 +234,48 @@ type ErrorDetail struct {
 	RootCause []RootCause `json:"root_cause,omitempty"`
 	Type      string      `json:"type,omitempty"`
 	Reason    string      `json:"reason,omitempty"`
+}
+
+func (d *ErrorDetail) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || bytes.Equal(data, []byte("null")) {
+		return nil
+	}
+
+	if len(data) > 0 && data[0] == '"' {
+		return json.Unmarshal(data, &d.Reason)
+	}
+
+	type alias ErrorDetail
+	var aux alias
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	*d = ErrorDetail(aux)
+	return nil
+}
+
+func (d *ErrorDetail) Message() string {
+	if d == nil {
+		return ""
+	}
+	if d.Reason != "" {
+		return d.Reason
+	}
+	if len(d.RootCause) > 0 {
+		var reasons []string
+		for _, cause := range d.RootCause {
+			if cause.Reason != "" {
+				reasons = append(reasons, cause.Reason)
+			} else if cause.Type != "" {
+				reasons = append(reasons, cause.Type)
+			}
+		}
+		if len(reasons) > 0 {
+			return strings.Join(reasons, "; ")
+		}
+	}
+	return d.Type
 }
 
 type RootCause struct {

--- a/core/elastic/index_test.go
+++ b/core/elastic/index_test.go
@@ -25,6 +25,8 @@ package elastic
 
 import (
 	"testing"
+
+	"github.com/segmentio/encoding/json"
 )
 
 func TestIndexDocument_GetStringFieldFromSource(t *testing.T) {
@@ -218,5 +220,33 @@ func TestIndexDocument_TryGetStringFieldFromSource(t *testing.T) {
 				)
 			}
 		})
+	}
+}
+
+func TestErrorDetailUnmarshalJSONString(t *testing.T) {
+	var detail ErrorDetail
+	if err := json.Unmarshal([]byte(`"initializing"`), &detail); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if detail.Reason != "initializing" {
+		t.Fatalf("unexpected reason: %q", detail.Reason)
+	}
+	if detail.Message() != "initializing" {
+		t.Fatalf("unexpected message: %q", detail.Message())
+	}
+}
+
+func TestErrorDetailUnmarshalJSONObject(t *testing.T) {
+	var detail ErrorDetail
+	if err := json.Unmarshal([]byte(`{"type":"search_phase_execution_exception","reason":"all shards failed"}`), &detail); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if detail.Type != "search_phase_execution_exception" {
+		t.Fatalf("unexpected type: %q", detail.Type)
+	}
+	if detail.Message() != "all shards failed" {
+		t.Fatalf("unexpected message: %q", detail.Message())
 	}
 }

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -24,6 +24,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add pluggable sink to host metrics collectors #288
 
 ### 🐛 Bug fix  
+- fix: parse string-form Elasticsearch initialization errors in search responses
 - fix: prevent duplicate bulk queue consumers during bulk indexing migrations #289
 ### ✈️ Improvements  
 - chore: API Handler Registration Improvements #283

--- a/modules/elastic/adapter/elasticsearch/v0.go
+++ b/modules/elastic/adapter/elasticsearch/v0.go
@@ -491,6 +491,20 @@ func (c *ESAPIV0) Get(indexName, docType, id string) (*elastic.GetResponse, erro
 		return esResp, err
 	}
 
+	if resp.StatusCode >= 400 {
+		if esResp.Error != nil {
+			errType := esResp.Error.Type
+			errReason := esResp.Error.Message()
+			if errType != "" && errReason != "" {
+				return esResp, errors.Errorf("status:%d, type:%s, reason:%s", resp.StatusCode, errType, errReason)
+			}
+			if errReason != "" {
+				return esResp, errors.Errorf("status:%d, reason:%s", resp.StatusCode, errReason)
+			}
+		}
+		return esResp, errors.Errorf("status:%d", resp.StatusCode)
+	}
+
 	return esResp, nil
 }
 


### PR DESCRIPTION
## Summary
- allow ErrorDetail to parse string-form Elasticsearch error payloads
- return clearer v0 search errors for 4xx/5xx responses during cluster initialization
- add a release note and targeted elastic tests without dropping existing coverage

## Testing
- go test ./core/elastic ./modules/elastic/adapter/elasticsearch

## Release notes
- fix: parse string-form Elasticsearch initialization errors in search responses