### PR TITLE
fix: clean stale elastic metadata refresh

### DIFF
--- a/modules/elastic/metadata.go
+++ b/modules/elastic/metadata.go
@@ -697,10 +697,13 @@ func (module *ElasticModule) updateNodeInfo(meta *elastic.ElasticsearchMetadata,
 	log.Trace("update node info")
 
 	if !force && !meta.IsAvailable() {
+		stateChanged := false
 		if !force {
-			setNodeUnknown(meta.Config.ID)
+			stateChanged = setNodeUnknown(meta.Config.ID)
 		}
-		log.Debugf("elasticsearch [%v] is not available, skip update node info", meta.Config.Name)
+		if stateChanged || rate.GetRateLimiter("metadata_node_info_skip", meta.Config.ID, 1, 1, 10*time.Minute).Allow() {
+			log.Debugf("elasticsearch [%v] is not available, skip update node info", meta.Config.Name)
+		}
 		return
 	}
 
@@ -808,17 +811,17 @@ func (module *ElasticModule) updateNodeInfo(meta *elastic.ElasticsearchMetadata,
 var saveNodeMetadataMutex = sync.Mutex{}
 var nodeAlreadyUnknown = map[string]bool{}
 
-func setNodeUnknown(clusterID string) {
+func setNodeUnknown(clusterID string) bool {
 	kv.DeleteKey(elastic.KVElasticNodeMetadata, []byte(clusterID))
 	meta := elastic.GetMetadata(clusterID)
 	if meta == nil {
-		return
+		return false
 	}
 	if meta.Config.Source != elastic.ElasticsearchConfigSourceElasticsearch {
-		return
+		return false
 	}
 	if v, ok := nodeAlreadyUnknown[clusterID]; ok && v {
-		return
+		return false
 	}
 	queueConfig := queue.GetOrInitConfig(elastic.QueueElasticIndexState)
 	if queueConfig.Labels == nil {
@@ -846,6 +849,7 @@ func setNodeUnknown(clusterID string) {
 	}
 
 	nodeAlreadyUnknown[clusterID] = true
+	return true
 }
 func saveNodeMetadata(nodes map[string]elastic.NodesInfo, clusterID string) error {
 	esConfig := elastic.GetConfig(clusterID)

--- a/modules/elastic/module.go
+++ b/modules/elastic/module.go
@@ -693,7 +693,18 @@ func (module *ElasticModule) refreshAllClusterMetadata() {
 		log.Trace("update elasticsearch's metadata:", v, ok)
 
 		if ok {
-			module.updateNodeInfo(v, false, v.Config.Discovery.Enabled)
+			cfg := elastic.GetConfigNoPanic(v.Config.ID)
+			if cfg == nil {
+				log.Debugf("elasticsearch metadata [%v] has no active config, removing stale metadata", v.Config.ID)
+				elastic.RemoveInstance(v.Config.ID)
+				elastic.RemoveHostsByClusterID(v.Config.ID)
+				return true
+			}
+			v.Config = cfg
+			if !cfg.Enabled || (cfg.MetadataConfigs != nil && !cfg.MetadataConfigs.MetadataRefresh.Enabled) {
+				return true
+			}
+			module.updateNodeInfo(v, false, cfg.Discovery.Enabled)
 		}
 		return true
 	})
@@ -706,6 +717,17 @@ func (module *ElasticModule) refreshAllClusterAlias(force bool) {
 		}
 		v, ok := value.(*elastic.ElasticsearchMetadata)
 		if ok {
+			cfg := elastic.GetConfigNoPanic(v.Config.ID)
+			if cfg == nil {
+				log.Debugf("elasticsearch metadata [%v] has no active config, removing stale metadata", v.Config.ID)
+				elastic.RemoveInstance(v.Config.ID)
+				elastic.RemoveHostsByClusterID(v.Config.ID)
+				return true
+			}
+			v.Config = cfg
+			if !cfg.Enabled || (cfg.MetadataConfigs != nil && !cfg.MetadataConfigs.MetadataRefresh.Enabled) {
+				return true
+			}
 			updateAliases(v, force)
 		}
 		return true


### PR DESCRIPTION
## Summary
- stop periodic metadata/alias refresh from processing stale metadata entries that no longer have an active config
- skip disabled clusters during metadata refresh and keep metadata configs in sync before refreshing
- rate-limit repeated unavailable node-info skip logs so the first transition is still visible without flooding gateway logs

## Testing
- go test ./modules/elastic ./core/elastic