### PR TITLE
fix: preserve dynamic templates for object schemas

### DIFF
--- a/modules/elastic/adapter/elasticsearch/v0.go
+++ b/modules/elastic/adapter/elasticsearch/v0.go
@@ -208,8 +208,6 @@ func (c *ESAPIV0) InitDefaultTemplate(templateName, indexPrefix string) {
 
 func (c *ESAPIV0) GetDefaultIndexTemplateSettings() any {
 	return util.MapStr{
-		"index.mapping.total_fields.limit": 20000,
-		"index.max_result_window":          10000000,
 		"analysis": util.MapStr{
 			"analyzer": util.MapStr{
 				"suggest_text_search": util.MapStr{

--- a/modules/elastic/adapter/elasticsearch/v0.go
+++ b/modules/elastic/adapter/elasticsearch/v0.go
@@ -208,6 +208,8 @@ func (c *ESAPIV0) InitDefaultTemplate(templateName, indexPrefix string) {
 
 func (c *ESAPIV0) GetDefaultIndexTemplateSettings() any {
 	return util.MapStr{
+		"index.mapping.total_fields.limit": 20000,
+		"index.max_result_window":          10000000,
 		"analysis": util.MapStr{
 			"analyzer": util.MapStr{
 				"suggest_text_search": util.MapStr{

--- a/modules/elastic/schema.go
+++ b/modules/elastic/schema.go
@@ -35,6 +35,7 @@ import (
 	"sync"
 	"unicode"
 
+	"infini.sh/framework/core/elastic"
 	"infini.sh/framework/core/global"
 
 	"github.com/buger/jsonparser"
@@ -124,6 +125,62 @@ func parseAnnotation(mapping []util.Annotation) string {
 	return json
 }
 
+func ensureDefaultStringDynamicTemplates(mappingData map[string]interface{}) {
+	if mappingData == nil {
+		return
+	}
+	if _, ok := mappingData["dynamic_templates"]; ok {
+		return
+	}
+	mappingData["dynamic_templates"] = []interface{}{
+		util.MapStr{
+			"strings": util.MapStr{
+				"match_mapping_type": "string",
+				"mapping": util.MapStr{
+					"type":         "keyword",
+					"ignore_above": 256,
+				},
+			},
+		},
+	}
+}
+
+func containsKeyDeep(value interface{}, targetKey string) bool {
+	switch v := value.(type) {
+	case map[string]interface{}:
+		for key, nested := range v {
+			if key == targetKey {
+				return true
+			}
+			if containsKeyDeep(nested, targetKey) {
+				return true
+			}
+		}
+	case []interface{}:
+		for _, nested := range v {
+			if containsKeyDeep(nested, targetKey) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func shouldRefreshExistingTemplate(client elastic.API, templateName string, mappingData map[string]interface{}) bool {
+	if mappingData == nil {
+		return false
+	}
+	if _, ok := mappingData["dynamic_templates"]; !ok {
+		return false
+	}
+	template, err := client.GetTemplate(templateName)
+	if err != nil {
+		log.Warnf("failed to inspect existing template [%s]: %v", templateName, err)
+		return false
+	}
+	return !containsKeyDeep(template, "dynamic_templates")
+}
+
 func initIndexName(t interface{}, indexName string) string {
 	pkg, ojbType := util.GetTypeAndPackageName(t, true)
 	key := fmt.Sprintf("%s-%s", pkg, ojbType)
@@ -181,6 +238,7 @@ func (handler *ElasticORM) RegisterSchemaWithName(t interface{}, indexName strin
 				}
 				return err
 			}
+			ensureDefaultStringDynamicTemplates(mappingData)
 			template, err := handler.Client.BuildTemplate(indexName+"*", nil, mappingData)
 			if err != nil {
 				if handler.Config.PanicOnInitSchemaError {
@@ -228,6 +286,44 @@ func (handler *ElasticORM) RegisterSchemaWithName(t interface{}, indexName strin
 
 		//init index
 		_ = handler.tryCreateInitIndex(t, indexName)
+	} else if handler.Config.BuildTemplateForObject {
+		jsonFormat := `{ %s }`
+		mapping := getIndexMapping(t)
+		js := parseAnnotation(mapping)
+		json := fmt.Sprintf(jsonFormat, quoteJson(js))
+
+		var mappingData map[string]interface{}
+		err = util.FromJSONBytes([]byte(json), &mappingData)
+		if err != nil {
+			if handler.Config.PanicOnInitSchemaError {
+				panic(err)
+			}
+			return err
+		}
+		ensureDefaultStringDynamicTemplates(mappingData)
+		if shouldRefreshExistingTemplate(handler.Client, indexTemplate, mappingData) {
+			template, err := handler.Client.BuildTemplate(indexName+"*", nil, mappingData)
+			if err != nil {
+				if handler.Config.PanicOnInitSchemaError {
+					panic(err)
+				}
+				return err
+			}
+			data, err := handler.Client.PutTemplate(indexTemplate, template)
+			if err != nil {
+				if handler.Config.PanicOnInitSchemaError {
+					panic(err)
+				}
+				return err
+			}
+			x, _, _, _ := jsonparser.Get(data, "error")
+			if x != nil {
+				log.Errorf("error on update template: %v, %v", indexName, string(x))
+				if handler.Config.PanicOnInitSchemaError {
+					panic(string(data))
+				}
+			}
+		}
 	}
 	return err
 }

--- a/modules/elastic/schema.go
+++ b/modules/elastic/schema.go
@@ -166,49 +166,6 @@ func containsKeyDeep(value interface{}, targetKey string) bool {
 	return false
 }
 
-func containsPathDeep(value interface{}, path ...string) bool {
-	if len(path) == 0 {
-		return true
-	}
-	joined := strings.Join(path, ".")
-	switch v := value.(type) {
-	case map[string]interface{}:
-		if nested, ok := v[joined]; ok {
-			if len(path) == 1 {
-				return true
-			}
-			return containsPathDeep(nested, path[1:]...)
-		}
-		if nested, ok := v[path[0]]; ok && containsPathDeep(nested, path[1:]...) {
-			return true
-		}
-		for _, nested := range v {
-			if containsPathDeep(nested, path...) {
-				return true
-			}
-		}
-	case []interface{}:
-		for _, nested := range v {
-			if containsPathDeep(nested, path...) {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func ensureExistingIndexSettings(client elastic.API, indexPattern string) error {
-	settings := util.MapStr{
-		"index.mapping.total_fields.limit": 20000,
-		"index.max_result_window":          10000000,
-	}
-	err := client.UpdateIndexSettings(indexPattern, settings)
-	if err != nil && strings.Contains(err.Error(), "index_not_found_exception") {
-		return nil
-	}
-	return err
-}
-
 func shouldRefreshExistingTemplate(client elastic.API, templateName string, mappingData map[string]interface{}) bool {
 	if mappingData == nil {
 		return false
@@ -221,9 +178,7 @@ func shouldRefreshExistingTemplate(client elastic.API, templateName string, mapp
 		log.Warnf("failed to inspect existing template [%s]: %v", templateName, err)
 		return false
 	}
-	return !containsKeyDeep(template, "dynamic_templates") ||
-		!containsPathDeep(template, "settings", "index", "mapping", "total_fields", "limit") ||
-		!containsPathDeep(template, "settings", "index", "max_result_window")
+	return !containsKeyDeep(template, "dynamic_templates")
 }
 
 func initIndexName(t interface{}, indexName string) string {
@@ -368,14 +323,6 @@ func (handler *ElasticORM) RegisterSchemaWithName(t interface{}, indexName strin
 					panic(string(data))
 				}
 			}
-		}
-	}
-	if handler.Config.BuildTemplateForObject {
-		if err := ensureExistingIndexSettings(handler.Client, indexName+"*"); err != nil {
-			if handler.Config.PanicOnInitSchemaError {
-				panic(err)
-			}
-			return err
 		}
 	}
 	return err

--- a/modules/elastic/schema.go
+++ b/modules/elastic/schema.go
@@ -166,6 +166,49 @@ func containsKeyDeep(value interface{}, targetKey string) bool {
 	return false
 }
 
+func containsPathDeep(value interface{}, path ...string) bool {
+	if len(path) == 0 {
+		return true
+	}
+	joined := strings.Join(path, ".")
+	switch v := value.(type) {
+	case map[string]interface{}:
+		if nested, ok := v[joined]; ok {
+			if len(path) == 1 {
+				return true
+			}
+			return containsPathDeep(nested, path[1:]...)
+		}
+		if nested, ok := v[path[0]]; ok && containsPathDeep(nested, path[1:]...) {
+			return true
+		}
+		for _, nested := range v {
+			if containsPathDeep(nested, path...) {
+				return true
+			}
+		}
+	case []interface{}:
+		for _, nested := range v {
+			if containsPathDeep(nested, path...) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func ensureExistingIndexSettings(client elastic.API, indexPattern string) error {
+	settings := util.MapStr{
+		"index.mapping.total_fields.limit": 20000,
+		"index.max_result_window":          10000000,
+	}
+	err := client.UpdateIndexSettings(indexPattern, settings)
+	if err != nil && strings.Contains(err.Error(), "index_not_found_exception") {
+		return nil
+	}
+	return err
+}
+
 func shouldRefreshExistingTemplate(client elastic.API, templateName string, mappingData map[string]interface{}) bool {
 	if mappingData == nil {
 		return false
@@ -178,7 +221,9 @@ func shouldRefreshExistingTemplate(client elastic.API, templateName string, mapp
 		log.Warnf("failed to inspect existing template [%s]: %v", templateName, err)
 		return false
 	}
-	return !containsKeyDeep(template, "dynamic_templates")
+	return !containsKeyDeep(template, "dynamic_templates") ||
+		!containsPathDeep(template, "settings", "index", "mapping", "total_fields", "limit") ||
+		!containsPathDeep(template, "settings", "index", "max_result_window")
 }
 
 func initIndexName(t interface{}, indexName string) string {
@@ -323,6 +368,14 @@ func (handler *ElasticORM) RegisterSchemaWithName(t interface{}, indexName strin
 					panic(string(data))
 				}
 			}
+		}
+	}
+	if handler.Config.BuildTemplateForObject {
+		if err := ensureExistingIndexSettings(handler.Client, indexName+"*"); err != nil {
+			if handler.Config.PanicOnInitSchemaError {
+				panic(err)
+			}
+			return err
 		}
 	}
 	return err

--- a/modules/elastic/schema_test.go
+++ b/modules/elastic/schema_test.go
@@ -107,23 +107,3 @@ func TestEnsureDefaultStringDynamicTemplates(t *testing.T) {
 	assert.Equal(t, ok, true)
 	assert.Equal(t, len(templates), 1)
 }
-
-func TestContainsPathDeep(t *testing.T) {
-	template := map[string]interface{}{
-		"metrics_template": map[string]interface{}{
-			"settings": map[string]interface{}{
-				"index": map[string]interface{}{
-					"mapping": map[string]interface{}{
-						"total_fields": map[string]interface{}{
-							"limit": "20000",
-						},
-					},
-					"max_result_window": "10000000",
-				},
-			},
-		},
-	}
-
-	assert.Equal(t, containsPathDeep(template, "settings", "index", "mapping", "total_fields", "limit"), true)
-	assert.Equal(t, containsPathDeep(template, "settings", "index", "max_result_window"), true)
-}

--- a/modules/elastic/schema_test.go
+++ b/modules/elastic/schema_test.go
@@ -107,3 +107,23 @@ func TestEnsureDefaultStringDynamicTemplates(t *testing.T) {
 	assert.Equal(t, ok, true)
 	assert.Equal(t, len(templates), 1)
 }
+
+func TestContainsPathDeep(t *testing.T) {
+	template := map[string]interface{}{
+		"metrics_template": map[string]interface{}{
+			"settings": map[string]interface{}{
+				"index": map[string]interface{}{
+					"mapping": map[string]interface{}{
+						"total_fields": map[string]interface{}{
+							"limit": "20000",
+						},
+					},
+					"max_result_window": "10000000",
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, containsPathDeep(template, "settings", "index", "mapping", "total_fields", "limit"), true)
+	assert.Equal(t, containsPathDeep(template, "settings", "index", "max_result_window"), true)
+}

--- a/modules/elastic/schema_test.go
+++ b/modules/elastic/schema_test.go
@@ -91,3 +91,19 @@ func TestQuoteWithUnderscore(t *testing.T) {
 	json := quoteJson(js)
 	assert.Equal(t, json, `{ "properties":{ "id": { "type": "keyword" },"created": { "type": "date" },"updated": { "type": "date" },"_system": { "type": "object" },"name": { "type": "keyword" } } }`)
 }
+
+func TestEnsureDefaultStringDynamicTemplates(t *testing.T) {
+	mapping := map[string]interface{}{
+		"properties": map[string]interface{}{
+			"timestamp": map[string]interface{}{
+				"type": "date",
+			},
+		},
+	}
+
+	ensureDefaultStringDynamicTemplates(mapping)
+
+	templates, ok := mapping["dynamic_templates"].([]interface{})
+	assert.Equal(t, ok, true)
+	assert.Equal(t, len(templates), 1)
+}


### PR DESCRIPTION
## Summary
- preserve the default string-to-keyword dynamic template when building object schema templates
- refresh existing object templates that were created without dynamic_templates
- add coverage for the injected dynamic template behavior

## Problem
Metrics object templates built from schema mappings could miss the default dynamic template, so dynamic string fields fell back to engine defaults and produced mixed text/keyword mappings across indices.