### PR TITLE
fix: resolve cluster auth from credential id

### DIFF
--- a/core/elastic/auth.go
+++ b/core/elastic/auth.go
@@ -24,12 +24,34 @@
 package elastic
 
 import (
+	"infini.sh/framework/core/credential"
 	"infini.sh/framework/core/errors"
+	"infini.sh/framework/core/orm"
 	"infini.sh/framework/core/util"
 	"infini.sh/framework/lib/fasthttp"
 )
 
 const EasysearchAPITokenHeader = "X-API-TOKEN"
+
+func resolveBasicAuth(cfg *ElasticsearchConfig) error {
+	if cfg == nil || cfg.BasicAuth != nil || cfg.CredentialID == "" {
+		return nil
+	}
+
+	cred := credential.Credential{}
+	cred.ID = cfg.CredentialID
+	_, err := orm.Get(&cred)
+	if err != nil {
+		return err
+	}
+
+	auth, err := cred.DecodeBasicAuth()
+	if err != nil {
+		return err
+	}
+	cfg.BasicAuth = auth
+	return nil
+}
 
 func ApplyAuthToRequestIfAvailable(req *util.Request, cfg *ElasticsearchConfig) error {
 	if req == nil {
@@ -38,6 +60,10 @@ func ApplyAuthToRequestIfAvailable(req *util.Request, cfg *ElasticsearchConfig) 
 
 	if cfg == nil {
 		return nil
+	}
+
+	if err := resolveBasicAuth(cfg); err != nil {
+		return err
 	}
 
 	if cfg.BasicAuth != nil {
@@ -60,6 +86,10 @@ func ApplyAuthToFastHTTPRequestIfAvailable(req *fasthttp.Request, cfg *Elasticse
 
 	if cfg == nil {
 		return nil
+	}
+
+	if err := resolveBasicAuth(cfg); err != nil {
+		return err
 	}
 
 	if cfg.BasicAuth != nil {


### PR DESCRIPTION
## Summary
- resolve basic auth from CredentialID before sending elasticsearch requests
- apply the same fallback for both normal and fast HTTP request helpers

## Problem
System and managed clusters can be stored with only CredentialID after setup. After restart, request auth helpers only checked BasicAuth and token fields, so requests like /_nodes were sent without credentials and clusters were marked unavailable.