### PR TITLE
feat: expose registered API and UI handlers

### DIFF
--- a/core/api/api.go
+++ b/core/api/api.go
@@ -136,6 +136,35 @@ func HandleAPIMethod(method Method, pattern string, handler func(w http.Response
 	l.Unlock()
 }
 
+func ServeRegisteredAPIRequest(w http.ResponseWriter, req *http.Request) {
+	localMux := http.NewServeMux()
+	localRouter := httprouter.New(localMux)
+	localRouter.NotFound = notfoundHandler
+
+	l.Lock()
+	defer l.Unlock()
+
+	for pattern, handler := range registeredAPIFuncHandler {
+		wrapped := handler
+		for _, f := range filters {
+			wrapped = f.FilterHttpHandlerFunc(pattern, wrapped)
+		}
+		localMux.HandleFunc(pattern, wrapped)
+	}
+
+	for method, handlers := range registeredAPIMethodHandler {
+		for pattern, handler := range handlers {
+			wrapped := handler
+			for _, f := range filters {
+				wrapped = f.FilterHttpRouter(pattern, wrapped)
+			}
+			localRouter.Handle(method, pattern, wrapped)
+		}
+	}
+
+	localRouter.ServeHTTP(w, req)
+}
+
 var router = httprouter.New(mux)
 var mux = http.NewServeMux()
 

--- a/core/api/api_test.go
+++ b/core/api/api_test.go
@@ -27,9 +27,12 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	httprouter "infini.sh/framework/core/api/router"
 )
 
 func TestStripPrefix(t *testing.T) {
@@ -109,5 +112,25 @@ func TestStripPrefix(t *testing.T) {
 					receivedPath, tc.expectedPathInHandler)
 			}
 		})
+	}
+}
+
+func TestServeRegisteredAPIRequest(t *testing.T) {
+	path := fmt.Sprintf("/__copilot_test__/api/%s/:id", t.Name())
+	HandleAPIMethod(GET, path, func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(ps.MustGetParameter("id") + ":" + req.URL.Query().Get("q")))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/__copilot_test__/api/%s/value?q=ok", t.Name()), nil)
+	recorder := httptest.NewRecorder()
+
+	ServeRegisteredAPIRequest(recorder, req)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("unexpected status: %d", recorder.Code)
+	}
+	if recorder.Body.String() != "value:ok" {
+		t.Fatalf("unexpected body: %s", recorder.Body.String())
 	}
 }

--- a/core/api/web.go
+++ b/core/api/web.go
@@ -30,6 +30,7 @@ package api
 import (
 	ctx "context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	_ "net/http/pprof"
 	"runtime"
@@ -55,6 +56,14 @@ var uiServeMux *http.ServeMux
 var uiMutex sync.Mutex
 
 var bindAddress string
+
+func ServeRegisteredUIRequest(w http.ResponseWriter, req *http.Request) error {
+	if uiRouter == nil {
+		return fmt.Errorf("web router is not initialized")
+	}
+	uiRouter.ServeHTTP(w, req)
+	return nil
+}
 
 func StopWeb(cfg config.WebAppConfig) {
 	if srv != nil {

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -27,7 +27,7 @@ Information about release notes of INFINI Framework is provided here.
 ### ✈️ Improvements  
 - feat(reverse): add shared reverse websocket protocol helpers (test: `go test ./core/api/websocket/reverse`) #303
 - feat(reverse): add reverse websocket session manager (test: `go test ./core/api/websocket/reverse`) #304
-- feat(api): expose registered API/UI handlers for in-process dispatch (test: `go test ./core/api`)
+- feat(api): expose registered API/UI handlers for in-process dispatch (test: `go test ./core/api`) #305
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -27,6 +27,7 @@ Information about release notes of INFINI Framework is provided here.
 ### ✈️ Improvements  
 - feat(reverse): add shared reverse websocket protocol helpers (test: `go test ./core/api/websocket/reverse`) #303
 - feat(reverse): add reverse websocket session manager (test: `go test ./core/api/websocket/reverse`) #304
+- feat(api): expose registered API/UI handlers for in-process dispatch (test: `go test ./core/api`)
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- expose registered API and UI handlers for in-process dispatch
- add focused API coverage for registered API request serving
- add release-notes entry with a focused test command

## Testing
- `GO111MODULE=off go test ./core/api`

## Notes
- stacked on `pr/framework-reverse-manager` to keep the diff single-purpose.
