### PR TITLE
feat: support configurable websocket message limits

### DIFF
--- a/core/api/websocket/conn.go
+++ b/core/api/websocket/conn.go
@@ -48,9 +48,11 @@ const (
 	// Send pings to peer with this period. Must be less than pongWait.
 	pingPeriod = (pongWait * 9) / 10
 
-	// Maximum message size allowed from peer.
-	maxMessageSize = 512
+	// Default maximum message size allowed from peer.
+	defaultMaxMessageSize int64 = 8 * 1024 * 1024
 )
+
+var maxMessageSize int64 = defaultMaxMessageSize
 
 var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,

--- a/core/api/websocket/hub.go
+++ b/core/api/websocket/hub.go
@@ -87,6 +87,7 @@ func (h *Hub) registerHandlers() {
 
 // InitWebSocket start websocket
 func InitWebSocket(cfg config.WebsocketConfig) {
+	maxMessageSize = resolveMaxMessageSize(cfg)
 	if cfg.SkipHostVerify {
 		upgrader.CheckOrigin = func(r *http.Request) bool {
 			return true
@@ -121,6 +122,13 @@ func InitWebSocket(cfg config.WebsocketConfig) {
 		go h.runHub(cfg)
 	}
 
+}
+
+func resolveMaxMessageSize(cfg config.WebsocketConfig) int64 {
+	if cfg.MaxMessageSizeBytes > 0 {
+		return cfg.MaxMessageSizeBytes
+	}
+	return defaultMaxMessageSize
 }
 
 // HandleWebSocketCommand used to register command and handler

--- a/core/api/websocket/hub_test.go
+++ b/core/api/websocket/hub_test.go
@@ -1,0 +1,36 @@
+package websocket
+
+import (
+	"testing"
+
+	"infini.sh/framework/core/config"
+)
+
+func TestResolveMaxMessageSize(t *testing.T) {
+	testCases := []struct {
+		name   string
+		cfg    config.WebsocketConfig
+		expect int64
+	}{
+		{
+			name:   "default",
+			cfg:    config.WebsocketConfig{},
+			expect: defaultMaxMessageSize,
+		},
+		{
+			name: "custom",
+			cfg: config.WebsocketConfig{
+				MaxMessageSizeBytes: 1024,
+			},
+			expect: 1024,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := resolveMaxMessageSize(tc.cfg); actual != tc.expect {
+				t.Fatalf("unexpected websocket message limit: got %d want %d", actual, tc.expect)
+			}
+		})
+	}
+}

--- a/core/config/system.go
+++ b/core/config/system.go
@@ -487,6 +487,7 @@ type WebsocketConfig struct {
 	EchoWelcomeMessageOnConnect bool     `config:"echo_welcome_message_on_connect"`
 	EchoLoggingConfigOnConnect  bool     `config:"echo_logging_config_on_connect"`
 	BasePath                    string   `config:"base_path"`
+	MaxMessageSizeBytes         int64    `config:"max_message_size_bytes"`
 	PermittedHosts              []string `config:"permitted_hosts"`
 	SkipHostVerify              bool     `config:"skip_host_verify"`
 }

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -28,7 +28,6 @@ Information about release notes of INFINI Framework is provided here.
 - feat(reverse): add shared reverse websocket protocol helpers (test: `go test ./core/api/websocket/reverse`) #303
 - feat(reverse): add reverse websocket session manager (test: `go test ./core/api/websocket/reverse`) #304
 - feat(api): expose registered API/UI handlers for in-process dispatch (test: `go test ./core/api`) #305
-- feat(websocket): support configurable websocket message size limits (test: `go test ./core/api/websocket`)
 - feat(config): add websocket max message size setting (test: `go test ./core/config`) #316
 - feat(websocket): support configurable websocket message size limits (test: `go test ./core/api/websocket`) #306
 - chore: API Handler Registration Improvements #283

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -28,6 +28,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(reverse): add shared reverse websocket protocol helpers (test: `go test ./core/api/websocket/reverse`) #303
 - feat(reverse): add reverse websocket session manager (test: `go test ./core/api/websocket/reverse`) #304
 - feat(api): expose registered API/UI handlers for in-process dispatch (test: `go test ./core/api`) #305
+- feat(config): add websocket max message size setting (test: `go test ./core/config`)
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -28,7 +28,9 @@ Information about release notes of INFINI Framework is provided here.
 - feat(reverse): add shared reverse websocket protocol helpers (test: `go test ./core/api/websocket/reverse`) #303
 - feat(reverse): add reverse websocket session manager (test: `go test ./core/api/websocket/reverse`) #304
 - feat(api): expose registered API/UI handlers for in-process dispatch (test: `go test ./core/api`) #305
-- feat(config): add websocket max message size setting (test: `go test ./core/config`)
+- feat(websocket): support configurable websocket message size limits (test: `go test ./core/api/websocket`)
+- feat(config): add websocket max message size setting (test: `go test ./core/config`) #316
+- feat(websocket): support configurable websocket message size limits (test: `go test ./core/api/websocket`) #306
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- support configurable websocket message size limits
- add focused websocket config coverage for max message size resolution
- add release-notes entry with a focused test command

## Testing
- `GO111MODULE=off go test ./core/api/websocket`

## Notes
- stacked on `pr/framework-reverse-ws-hooks` to keep the diff single-purpose.
