### PR TITLE
feat(configs): add token-based manager auth helpers

### DIFF
--- a/core/credential/credential.go
+++ b/core/credential/credential.go
@@ -69,10 +69,13 @@ func (cred *Credential) Encode() error {
 	switch cred.Type {
 	case BasicAuth:
 		return encodeBasicAuth(cred)
+	case Token:
+		return encodeToken(cred)
 	default:
 		return fmt.Errorf("unkonow credential type [%s]", cred.Type)
 	}
 }
+
 func (cred *Credential) DecodeBasicAuth() (*model.BasicAuth, error) {
 	var dv interface{}
 	dv, err := cred.Decode()
@@ -86,10 +89,23 @@ func (cred *Credential) DecodeBasicAuth() (*model.BasicAuth, error) {
 	return nil, fmt.Errorf("unkonow credential type [%s]", cred.Type)
 }
 
+func (cred *Credential) DecodeToken() (string, error) {
+	dv, err := cred.Decode()
+	if err != nil {
+		return "", err
+	}
+	if token, ok := dv.(model.Token); ok {
+		return token.Value, nil
+	}
+	return "", fmt.Errorf("unkonow credential type [%s]", cred.Type)
+}
+
 func (cred *Credential) Decode() (interface{}, error) {
 	switch cred.Type {
 	case BasicAuth:
 		return decodeBasicAuth(cred)
+	case Token:
+		return decodeToken(cred)
 	default:
 		return nil, fmt.Errorf("unkonow credential type [%s]", cred.Type)
 	}
@@ -97,4 +113,5 @@ func (cred *Credential) Decode() (interface{}, error) {
 
 const (
 	BasicAuth string = "basic_auth"
+	Token     string = "token"
 )

--- a/core/credential/credential_test.go
+++ b/core/credential/credential_test.go
@@ -1,0 +1,125 @@
+package credential
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"infini.sh/framework/core/keystore"
+)
+
+var credentialTestKeystoreDir string
+var credentialTestKeystoreOnce sync.Once
+
+func useCredentialTestKeystore(t *testing.T) {
+	t.Helper()
+
+	credentialTestKeystoreOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "framework-credential-keystore-*")
+		if err != nil {
+			t.Fatalf("create credential test keystore dir: %v", err)
+		}
+		credentialTestKeystoreDir = dir
+	})
+
+	t.Setenv(keystore.PathEnvKey, credentialTestKeystoreDir)
+}
+
+func TestTokenCredentialRoundTrip(t *testing.T) {
+	useCredentialTestKeystore(t)
+
+	cred := &Credential{
+		Name: "agent token",
+		Type: Token,
+		Payload: map[string]interface{}{
+			Token: map[string]interface{}{
+				"value": "super-secret-token",
+			},
+		},
+	}
+
+	if err := cred.Encode(); err != nil {
+		t.Fatalf("encode token credential: %v", err)
+	}
+
+	encryptedValue, ok := cred.Payload[Token].(map[string]interface{})["value"].(string)
+	if !ok || encryptedValue == "" || encryptedValue == "super-secret-token" {
+		t.Fatalf("expected encrypted token payload, got %#v", cred.Payload[Token])
+	}
+
+	value, err := cred.DecodeToken()
+	if err != nil {
+		t.Fatalf("decode token credential: %v", err)
+	}
+	if value != "super-secret-token" {
+		t.Fatalf("unexpected token value: %q", value)
+	}
+}
+
+func TestEncodeTokenRejectsInvalidPayload(t *testing.T) {
+	useCredentialTestKeystore(t)
+
+	tests := []struct {
+		name    string
+		payload map[string]interface{}
+	}{
+		{
+			name: "wrong payload type",
+			payload: map[string]interface{}{
+				Token: "invalid",
+			},
+		},
+		{
+			name: "wrong token value type",
+			payload: map[string]interface{}{
+				Token: map[string]interface{}{
+					"value": 1,
+				},
+			},
+		},
+		{
+			name: "empty token value",
+			payload: map[string]interface{}{
+				Token: map[string]interface{}{
+					"value": "",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cred := &Credential{
+				Name:    "invalid token",
+				Type:    Token,
+				Payload: tc.payload,
+			}
+			if err := cred.Encode(); err == nil {
+				t.Fatal("expected token encode error")
+			}
+		})
+	}
+}
+
+func TestDecodeTokenRejectsOtherCredentialType(t *testing.T) {
+	useCredentialTestKeystore(t)
+
+	cred := &Credential{
+		Name: "basic auth",
+		Type: BasicAuth,
+		Payload: map[string]interface{}{
+			BasicAuth: map[string]interface{}{
+				"username": "admin",
+				"password": "admin",
+			},
+		},
+	}
+
+	if err := cred.Encode(); err != nil {
+		t.Fatalf("encode basic auth credential: %v", err)
+	}
+
+	if _, err := cred.DecodeToken(); err == nil {
+		t.Fatal("expected decode token to reject basic auth credential")
+	}
+}

--- a/core/credential/domain.go
+++ b/core/credential/domain.go
@@ -157,6 +157,71 @@ func decodeBasicAuth(cred *Credential) (basicAuth model.BasicAuth, err error) {
 	return
 }
 
+func encodeToken(cred *Credential) error {
+	params, ok := cred.Payload[cred.Type].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("wrong credential parameters for type [%s], expect a map", cred.Type)
+	}
+	value, ok := params["value"].(string)
+	if !ok {
+		return fmt.Errorf("wrong credential parameters value for type [%s], expect a string", cred.Type)
+	}
+	if value == "" {
+		return fmt.Errorf("credential parameters value can not be empty")
+	}
+
+	secret, err := GetOrInitSecret()
+	if err != nil {
+		return err
+	}
+	encodeBytes, salt, err := util.AesGcmEncrypt([]byte(value), secret)
+	if err != nil {
+		return fmt.Errorf("encrypt token value error: %w", err)
+	}
+	cred.Encrypt.Type = "AES"
+	cred.Encrypt.Params = map[string]interface{}{
+		"salt": string(salt),
+	}
+	params["value"] = string(encodeBytes)
+	cred.Payload[cred.Type] = params
+	return nil
+}
+
+func decodeToken(cred *Credential) (token model.Token, err error) {
+	params, ok := cred.Payload[cred.Type].(map[string]interface{})
+	if !ok {
+		err = fmt.Errorf("wrong credential parameters for type [%s], expect a map", cred.Type)
+		return
+	}
+	value, ok := params["value"].(string)
+	if !ok {
+		err = fmt.Errorf("wrong credential parameters value for type [%s], expect a string", cred.Type)
+		return
+	}
+	if value == "" {
+		err = fmt.Errorf("credential parameters value can not be empty")
+		return
+	}
+	salt, ok := cred.Encrypt.Params["salt"].(string)
+	if !ok {
+		err = fmt.Errorf("credential encrypt parameters salt can not be empty")
+		return
+	}
+	secret := cred.secret
+	if secret == nil {
+		secret, err = GetOrInitSecret()
+		if err != nil {
+			return token, err
+		}
+	}
+	plaintext, err := util.AesGcmDecrypt([]byte(value), secret, []byte(salt))
+	if err != nil {
+		return token, err
+	}
+	token.Value = string(plaintext)
+	return
+}
+
 type ChangeEvent func(credentials *Credential)
 
 var changeEvents []ChangeEvent

--- a/core/model/instance.go
+++ b/core/model/instance.go
@@ -56,6 +56,9 @@ type Instance struct {
 
 	BasicAuth *BasicAuth `config:"basic_auth" json:"basic_auth,omitempty" elastic_mapping:"basic_auth:{type:object}"`
 
+	ManagerCredentialID string `json:"manager_credential_id,omitempty" elastic_mapping:"manager_credential_id:{type:keyword}"`
+	AccessCredentialID  string `json:"access_credential_id,omitempty" elastic_mapping:"access_credential_id:{type:keyword}"`
+
 	Labels map[string]string `json:"labels,omitempty" elastic_mapping:"labels:{type:object}"`
 	Tags   []string          `json:"tags,omitempty"`
 

--- a/core/model/token.go
+++ b/core/model/token.go
@@ -1,0 +1,32 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Framework is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+/* Copyright © INFINI LTD. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package model
+
+type Token struct {
+	Value string `json:"value,omitempty" config:"value"`
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,6 +23,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(cookie): prevent aggressive session cookie expiration #284
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
+- feat(configs): add token-based manager registration helpers (test: `go test ./core/credential ./modules/configs/common ./modules/configs/client`)
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,7 +23,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(cookie): prevent aggressive session cookie expiration #284
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
-- feat(configs): add token-based manager registration helpers (test: `go test ./core/credential ./modules/configs/common ./modules/configs/client`)
+- feat(configs): add token-based manager registration helpers (test: `go test ./core/credential ./modules/configs/common ./modules/configs/client`) #307
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  

--- a/modules/configs/client/client.go
+++ b/modules/configs/client/client.go
@@ -77,11 +77,15 @@ func ConnectToManager() error {
 	}
 
 	info := model.GetInstanceInfo()
+	registerReq, err := buildRegisterRequest(info)
+	if err != nil {
+		return err
+	}
 
 	req := util.Request{Method: util.Verb_POST}
 	req.ContentType = "application/json"
 	req.Path = common.REGISTER_API
-	req.Body = util.MustToJSONBytes(info)
+	req.Body = util.MustToJSONBytes(registerReq)
 
 	server, res, err := submitRequestToManager(&req)
 	if err == nil && server != "" {
@@ -99,11 +103,37 @@ func ConnectToManager() error {
 	return err
 }
 
+func buildRegisterRequest(info model.Instance) (common.InstanceRegisterRequest, error) {
+	registerReq := common.InstanceRegisterRequest{
+		Client: info,
+	}
+	if info.Application.Name != "agent" {
+		return registerReq, nil
+	}
+
+	accessToken, err := common.EnsureTokenInKeystore(common.AgentAccessTokenKeystoreKey)
+	if err != nil {
+		return registerReq, err
+	}
+	registerReq.AccessToken = &common.RegisterToken{
+		Name:        fmt.Sprintf("%s reverse access token", info.ID),
+		Description: fmt.Sprintf("Console to Agent access token for instance %s", info.ID),
+		Value:       accessToken,
+	}
+	return registerReq, nil
+}
+
 func submitRequestToManager(req *util.Request) (string, *util.Result, error) {
 	var err error
 	var res *util.Result
 	cfg := global.Env().SystemConfig.Configs
-	if cfg.ManagerConfig.BasicAuth.Username != "" {
+	token, err := common.LoadTokenFromKeystore(common.ManagerTokenKeystoreKey)
+	if err != nil {
+		return "", nil, err
+	}
+	if token != "" {
+		req.AddHeader("Authorization", "Bearer "+token)
+	} else if cfg.ManagerConfig.BasicAuth.Username != "" {
 		req.SetBasicAuth(cfg.ManagerConfig.BasicAuth.Username, cfg.ManagerConfig.BasicAuth.Password.Get())
 	}
 	for _, server := range cfg.Servers {

--- a/modules/configs/client/client_test.go
+++ b/modules/configs/client/client_test.go
@@ -1,0 +1,145 @@
+package client
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+
+	"infini.sh/framework/core/config"
+	"infini.sh/framework/core/env"
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/keystore"
+	"infini.sh/framework/core/model"
+	"infini.sh/framework/core/util"
+	"infini.sh/framework/lib/go-ucfg"
+	"infini.sh/framework/modules/configs/common"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+var clientTestKeystoreDir string
+var clientTestKeystoreOnce sync.Once
+
+func useClientTestKeystore(t *testing.T) {
+	t.Helper()
+
+	clientTestKeystoreOnce.Do(func() {
+		dir, err := os.MkdirTemp("", "framework-client-keystore-*")
+		if err != nil {
+			t.Fatalf("create client test keystore dir: %v", err)
+		}
+		clientTestKeystoreDir = dir
+	})
+
+	t.Setenv(keystore.PathEnvKey, clientTestKeystoreDir)
+}
+
+func TestBuildRegisterRequestAddsAgentAccessToken(t *testing.T) {
+	useClientTestKeystore(t)
+
+	info := model.Instance{}
+	info.ID = "agent-1"
+	info.Application = env.Application{Name: "agent"}
+
+	req, err := buildRegisterRequest(info)
+	if err != nil {
+		t.Fatalf("build register request: %v", err)
+	}
+	if req.AccessToken == nil {
+		t.Fatal("expected agent access token in register request")
+	}
+	if req.AccessToken.Name != "agent-1 reverse access token" {
+		t.Fatalf("unexpected access token name: %q", req.AccessToken.Name)
+	}
+	if req.AccessToken.Value == "" {
+		t.Fatal("expected generated access token value")
+	}
+
+	req2, err := buildRegisterRequest(info)
+	if err != nil {
+		t.Fatalf("build register request second call: %v", err)
+	}
+	if req2.AccessToken == nil || req2.AccessToken.Value != req.AccessToken.Value {
+		t.Fatal("expected agent access token to be reused")
+	}
+}
+
+func TestBuildRegisterRequestSkipsAccessTokenForNonAgent(t *testing.T) {
+	info := model.Instance{}
+	info.ID = "gateway-1"
+	info.Application = env.Application{Name: "gateway"}
+
+	req, err := buildRegisterRequest(info)
+	if err != nil {
+		t.Fatalf("build register request: %v", err)
+	}
+	if req.AccessToken != nil {
+		t.Fatalf("expected no access token for non-agent instance, got %#v", req.AccessToken)
+	}
+}
+
+func TestSubmitRequestToManagerPrefersBearerToken(t *testing.T) {
+	useClientTestKeystore(t)
+
+	envRef := global.Env()
+	originalConfig := envRef.SystemConfig
+	originalClient := mTLSClient
+	t.Cleanup(func() {
+		envRef.SystemConfig = originalConfig
+		mTLSClient = originalClient
+	})
+
+	systemConfig := &config.SystemConfig{}
+	systemConfig.Configs.Servers = []string{"http://manager.example:8080"}
+	systemConfig.Configs.ManagerConfig.BasicAuth.Username = "admin"
+	systemConfig.Configs.ManagerConfig.BasicAuth.Password = ucfg.SecretString("secret")
+	envRef.SystemConfig = systemConfig
+
+	if err := common.SaveTokenToKeystore(common.ManagerTokenKeystoreKey, "bearer-token"); err != nil {
+		t.Fatalf("save manager token: %v", err)
+	}
+
+	var authHeader string
+	var requestBody []byte
+	mTLSClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			authHeader = req.Header.Get("Authorization")
+			requestBody, _ = io.ReadAll(req.Body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader([]byte(`{"ok":true}`))),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}),
+	}
+
+	req := &util.Request{
+		Method: util.Verb_POST,
+		Path:   common.REGISTER_API,
+		Body:   []byte(`{"hello":"world"}`),
+	}
+	server, res, err := submitRequestToManager(req)
+	if err != nil {
+		t.Fatalf("submit request to manager: %v", err)
+	}
+	if server != "http://manager.example:8080" {
+		t.Fatalf("unexpected server: %s", server)
+	}
+	if res == nil || res.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected response: %#v", res)
+	}
+	if authHeader != "Bearer bearer-token" {
+		t.Fatalf("unexpected authorization header: %q", authHeader)
+	}
+	if string(requestBody) != `{"hello":"world"}` {
+		t.Fatalf("unexpected request body: %s", string(requestBody))
+	}
+}

--- a/modules/configs/common/domain.go
+++ b/modules/configs/common/domain.go
@@ -32,6 +32,22 @@ import "infini.sh/framework/core/model"
 const REGISTER_API = "/instance/_register"
 const SYNC_API = "/configs/_sync"
 
+const (
+	ManagerTokenKeystoreKey     = "configs_manager_token"
+	AgentAccessTokenKeystoreKey = "agent_access_token"
+)
+
+type RegisterToken struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	Value       string `json:"value,omitempty"`
+}
+
+type InstanceRegisterRequest struct {
+	Client      model.Instance `json:"client"`
+	AccessToken *RegisterToken `json:"access_token,omitempty"`
+}
+
 type ConfigFile struct {
 	Name     string `json:"name,omitempty"`
 	Location string `json:"location,omitempty"`

--- a/modules/configs/common/token.go
+++ b/modules/configs/common/token.go
@@ -1,0 +1,74 @@
+// Copyright (C) INFINI Labs & INFINI LIMITED.
+//
+// The INFINI Framework is offered under the GNU Affero General Public License v3.0
+// and as commercial software.
+//
+// For commercial licensing, contact us at:
+//   - Website: infinilabs.com
+//   - Email: hello@infini.ltd
+//
+// Open Source licensed under AGPL V3:
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+/* Copyright © INFINI LTD. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+
+package common
+
+import (
+	"strings"
+	"sync"
+
+	"infini.sh/framework/core/keystore"
+	"infini.sh/framework/core/util"
+	keystore2 "infini.sh/framework/lib/keystore"
+)
+
+// These helpers persist transport tokens directly in the local keystore.
+// Server-side persisted credentials still use core/credential.
+var tokenKeystoreLock sync.Mutex
+
+func LoadTokenFromKeystore(key string) (string, error) {
+	value, err := keystore.GetValue(key)
+	if err == keystore2.ErrKeyDoesntExists {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(value)), nil
+}
+
+func SaveTokenToKeystore(key, value string) error {
+	return keystore.SetValue(key, util.UnsafeStringToBytes(strings.TrimSpace(value)))
+}
+
+func EnsureTokenInKeystore(key string) (string, error) {
+	tokenKeystoreLock.Lock()
+	defer tokenKeystoreLock.Unlock()
+
+	value, err := LoadTokenFromKeystore(key)
+	if err != nil {
+		return "", err
+	}
+	if value != "" {
+		return value, nil
+	}
+	value = util.GenerateRandomString(48)
+	if err := SaveTokenToKeystore(key, value); err != nil {
+		return "", err
+	}
+	return value, nil
+}

--- a/modules/configs/common/token_test.go
+++ b/modules/configs/common/token_test.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"testing"
+
+	"infini.sh/framework/core/keystore"
+)
+
+func TestEnsureTokenInKeystoreReusesStoredValue(t *testing.T) {
+	t.Setenv(keystore.PathEnvKey, t.TempDir())
+
+	first, err := EnsureTokenInKeystore(ManagerTokenKeystoreKey)
+	if err != nil {
+		t.Fatalf("ensure token first call: %v", err)
+	}
+	if len(first) != 48 {
+		t.Fatalf("unexpected token length: %d", len(first))
+	}
+
+	second, err := EnsureTokenInKeystore(ManagerTokenKeystoreKey)
+	if err != nil {
+		t.Fatalf("ensure token second call: %v", err)
+	}
+	if second != first {
+		t.Fatalf("expected stored token to be reused, got %q and %q", first, second)
+	}
+
+	loaded, err := LoadTokenFromKeystore(ManagerTokenKeystoreKey)
+	if err != nil {
+		t.Fatalf("load token from keystore: %v", err)
+	}
+	if loaded != first {
+		t.Fatalf("unexpected loaded token: %q", loaded)
+	}
+}


### PR DESCRIPTION
## Summary
- add `token` credential encoding/decoding support for persisted framework credentials
- add managed-config token helpers and registration payload types for manager/agent token exchange
- make config client prefer bearer tokens from keystore and let agent registration include its generated access token

## Testing
- `GO111MODULE=off go test ./core/model`
- `GO111MODULE=off go test ./core/credential ./modules/configs/common ./modules/configs/client`
