### PR TITLE
feat(model): expose managed api and web service endpoints

### DIFF
--- a/core/model/instance.go
+++ b/core/model/instance.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
+	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/env"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/host"
@@ -126,6 +127,33 @@ func (inst *Instance) GetVersion() (map[string]interface{}, error) {
 	return nil, fmt.Errorf("unknow agent version")
 }
 
+func resolveManagedInstanceEndpoint(apiConfig config.APIConfig, webConfig config.WebAppConfig) string {
+	if apiConfig.Enabled {
+		return apiConfig.GetEndpoint()
+	}
+	if webConfig.Enabled {
+		return webConfig.GetEndpoint()
+	}
+	return apiConfig.GetEndpoint()
+}
+
+func buildManagedInstanceServices(apiConfig config.APIConfig, webConfig config.WebAppConfig) []ServiceInfo {
+	services := []ServiceInfo{}
+	if apiConfig.Enabled {
+		services = append(services, ServiceInfo{
+			Name:     "api",
+			Endpoint: apiConfig.GetEndpoint(),
+		})
+	}
+	if webConfig.Enabled {
+		services = append(services, ServiceInfo{
+			Name:     "web",
+			Endpoint: webConfig.GetEndpoint(),
+		})
+	}
+	return services
+}
+
 func GetInstanceInfo() Instance {
 	instance := Instance{}
 	instance.ID = global.Env().SystemConfig.NodeConfig.ID
@@ -137,7 +165,8 @@ func GetInstanceInfo() Instance {
 
 	_, publicIP, _, _ := util.GetPublishNetworkDeviceInfo(global.Env().SystemConfig.NodeConfig.MajorIpPattern)
 
-	instance.Endpoint = global.Env().SystemConfig.APIConfig.GetEndpoint()
+	instance.Endpoint = resolveManagedInstanceEndpoint(global.Env().SystemConfig.APIConfig, global.Env().SystemConfig.WebAppConfig)
+	instance.Services = buildManagedInstanceServices(global.Env().SystemConfig.APIConfig, global.Env().SystemConfig.WebAppConfig)
 
 	ips := util.GetLocalIPs()
 	if len(ips) > 0 {

--- a/core/model/instance_test.go
+++ b/core/model/instance_test.go
@@ -1,0 +1,51 @@
+package model
+
+import (
+	"testing"
+
+	"infini.sh/framework/core/config"
+)
+
+func TestResolveManagedInstanceEndpoint(t *testing.T) {
+	t.Run("prefer api endpoint when api is enabled", func(t *testing.T) {
+		apiConfig := config.APIConfig{Enabled: true}
+		apiConfig.NetworkConfig.Publish = "127.0.0.1:2900"
+		webConfig := config.WebAppConfig{Enabled: true}
+		webConfig.NetworkConfig.Publish = "127.0.0.1:8080"
+
+		endpoint := resolveManagedInstanceEndpoint(apiConfig, webConfig)
+		if endpoint != "http://127.0.0.1:2900" {
+			t.Fatalf("unexpected endpoint: %s", endpoint)
+		}
+	})
+
+	t.Run("fallback to web endpoint when api is disabled", func(t *testing.T) {
+		apiConfig := config.APIConfig{Enabled: false}
+		apiConfig.NetworkConfig.Publish = "127.0.0.1:2900"
+		webConfig := config.WebAppConfig{Enabled: true}
+		webConfig.NetworkConfig.Publish = "127.0.0.1:8080"
+
+		endpoint := resolveManagedInstanceEndpoint(apiConfig, webConfig)
+		if endpoint != "http://127.0.0.1:8080" {
+			t.Fatalf("unexpected endpoint: %s", endpoint)
+		}
+	})
+}
+
+func TestBuildManagedInstanceServices(t *testing.T) {
+	apiConfig := config.APIConfig{Enabled: true}
+	apiConfig.NetworkConfig.Publish = "127.0.0.1:2900"
+	webConfig := config.WebAppConfig{Enabled: true}
+	webConfig.NetworkConfig.Publish = "127.0.0.1:8080"
+
+	services := buildManagedInstanceServices(apiConfig, webConfig)
+	if len(services) != 2 {
+		t.Fatalf("unexpected service count: %#v", services)
+	}
+	if services[0].Name != "api" || services[0].Endpoint != "http://127.0.0.1:2900" {
+		t.Fatalf("unexpected api service: %#v", services[0])
+	}
+	if services[1].Name != "web" || services[1].Endpoint != "http://127.0.0.1:8080" {
+		t.Fatalf("unexpected web service: %#v", services[1])
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,7 +23,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(cookie): prevent aggressive session cookie expiration #284
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
-- feat(model): expose managed api and web service endpoints (test: `go test ./core/model`)
+- feat(model): expose managed api and web service endpoints (test: `go test ./core/model`) #308
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,6 +23,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(cookie): prevent aggressive session cookie expiration #284
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
+- feat(model): expose managed api and web service endpoints (test: `go test ./core/model`)
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  


### PR DESCRIPTION
## Summary
- prefer the managed API endpoint when it is enabled, while falling back to the web endpoint when only the web listener is available
- publish managed `api` and `web` service endpoints in instance metadata for downstream callers that need listener-aware routing
- cover the endpoint selection and service list helpers with focused `core/model` tests

## Testing
- `GO111MODULE=off go test ./core/model`
