### PR TITLE
feat(orm): deduplicate repeated schema registrations

### DIFF
--- a/core/orm/registry.go
+++ b/core/orm/registry.go
@@ -10,6 +10,11 @@ import (
 
 var registeredSchemas = []util.KeyValue{}
 
+func schemaRegistrationKey(t interface{}) string {
+	pkg, typeName := util.GetTypeAndPackageName(t, true)
+	return pkg + "-" + typeName
+}
+
 func MustRegisterSchemaWithIndexName(t interface{}, index string) {
 	err := RegisterSchemaWithIndexName(t, index)
 	if err != nil {
@@ -18,6 +23,17 @@ func MustRegisterSchemaWithIndexName(t interface{}, index string) {
 }
 
 func RegisterSchemaWithIndexName(t interface{}, index string) error {
+	newKey := schemaRegistrationKey(t)
+	for _, registered := range registeredSchemas {
+		if registered.Key != index {
+			continue
+		}
+		existingKey := schemaRegistrationKey(registered.Payload)
+		if existingKey == newKey {
+			return nil
+		}
+		return errors.Errorf("schema index [%s] already registered by [%s]", index, existingKey)
+	}
 	registeredSchemas = append(registeredSchemas, util.KeyValue{Key: index, Payload: t})
 	return nil
 }

--- a/core/orm/registry_test.go
+++ b/core/orm/registry_test.go
@@ -1,0 +1,39 @@
+package orm
+
+import "testing"
+
+type testSchemaAlpha struct{}
+type testSchemaBeta struct{}
+
+func TestRegisterSchemaWithIndexNameDeduplicatesSameSchema(t *testing.T) {
+	original := registeredSchemas
+	registeredSchemas = nil
+	t.Cleanup(func() {
+		registeredSchemas = original
+	})
+
+	if err := RegisterSchemaWithIndexName(testSchemaAlpha{}, "test-index"); err != nil {
+		t.Fatalf("expected first registration to succeed, got %v", err)
+	}
+	if err := RegisterSchemaWithIndexName(&testSchemaAlpha{}, "test-index"); err != nil {
+		t.Fatalf("expected duplicate registration to be ignored, got %v", err)
+	}
+	if len(registeredSchemas) != 1 {
+		t.Fatalf("expected exactly one registered schema, got %d", len(registeredSchemas))
+	}
+}
+
+func TestRegisterSchemaWithIndexNameRejectsDifferentSchemaForSameIndex(t *testing.T) {
+	original := registeredSchemas
+	registeredSchemas = nil
+	t.Cleanup(func() {
+		registeredSchemas = original
+	})
+
+	if err := RegisterSchemaWithIndexName(testSchemaAlpha{}, "test-index"); err != nil {
+		t.Fatalf("expected first registration to succeed, got %v", err)
+	}
+	if err := RegisterSchemaWithIndexName(testSchemaBeta{}, "test-index"); err == nil {
+		t.Fatal("expected conflicting registration to fail")
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,7 +23,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(cookie): prevent aggressive session cookie expiration #284
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
-- feat(orm): deduplicate repeated schema registrations (test: `go test ./core/orm`)
+- feat(orm): deduplicate repeated schema registrations (test: `go test ./core/orm`) #309
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,6 +23,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(cookie): prevent aggressive session cookie expiration #284
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
+- feat(orm): deduplicate repeated schema registrations (test: `go test ./core/orm`)
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  


### PR DESCRIPTION
## Summary
- ignore repeated registrations of the same schema on the same index
- reject conflicting attempts to register different schemas on an already claimed index
- cover both dedupe and conflict paths with focused ORM tests

## Testing
- `GO111MODULE=off go test ./core/orm`
