### PR TITLE
feat(task): support initial delay for interval tasks

### DIFF
--- a/core/task/chrono/task.go
+++ b/core/task/chrono/task.go
@@ -35,9 +35,10 @@ import (
 type Task func(ctx context.Context)
 
 type SchedulerTask struct {
-	task      Task
-	startTime time.Time
-	location  *time.Location
+	task         Task
+	startTime    time.Time
+	initialDelay time.Duration
+	location     *time.Location
 }
 
 func CreateSchedulerTask(task Task, options ...Option) (*SchedulerTask, error) {
@@ -46,9 +47,10 @@ func CreateSchedulerTask(task Task, options ...Option) (*SchedulerTask, error) {
 	}
 
 	runnableTask := &SchedulerTask{
-		task:      task,
-		startTime: time.Time{},
-		location:  time.Local,
+		task:         task,
+		startTime:    time.Time{},
+		initialDelay: 0,
+		location:     time.Local,
 	}
 
 	for _, option := range options {
@@ -63,6 +65,10 @@ func CreateSchedulerTask(task Task, options ...Option) (*SchedulerTask, error) {
 }
 
 func (task *SchedulerTask) GetInitialDelay() time.Duration {
+	if task.initialDelay > 0 {
+		return task.initialDelay
+	}
+
 	if task.startTime.IsZero() {
 		return 0
 	}
@@ -83,6 +89,16 @@ type Option func(task *SchedulerTask) error
 func WithStartTime(year int, month time.Month, day, hour, min, sec int) Option {
 	return func(task *SchedulerTask) error {
 		task.startTime = time.Date(year, month, day, hour, min, sec, 0, time.Local)
+		return nil
+	}
+}
+
+func WithInitialDelay(delay time.Duration) Option {
+	return func(task *SchedulerTask) error {
+		if delay < 0 {
+			delay = 0
+		}
+		task.initialDelay = delay
 		return nil
 	}
 }

--- a/core/task/chrono/task_test.go
+++ b/core/task/chrono/task_test.go
@@ -52,6 +52,16 @@ func TestNewSchedulerTask_WithInvalidLocation(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestNewSchedulerTask_WithInitialDelay(t *testing.T) {
+	task, err := CreateSchedulerTask(func(ctx context.Context) {
+	}, WithInitialDelay(200*time.Millisecond))
+	assert.Nil(t, err)
+
+	delay := task.GetInitialDelay()
+	assert.Greater(t, delay, 0*time.Millisecond)
+	assert.LessOrEqual(t, delay, 200*time.Millisecond)
+}
+
 func TestNewScheduledRunnableTask(t *testing.T) {
 	task, _ := CreateScheduledRunnableTask(0, func(ctx context.Context) {
 

--- a/core/task/task.go
+++ b/core/task/task.go
@@ -128,15 +128,16 @@ func RegisterTransientTask(group, tag string, f func(ctx context.Context) error,
 }
 
 type ScheduleTask struct {
-	ID          string     `config:"id" json:"id,omitempty"`
-	Group       string     `config:"group" json:"group,omitempty"`
-	Description string     `config:"description" json:"description,omitempty"`
-	Type        string     `config:"type" json:"type,omitempty"`
-	Interval    string     `config:"interval" json:"interval,omitempty"`
-	Crontab     string     `config:"crontab" json:"crontab,omitempty"`
-	CreateTime  time.Time  `config:"create_time" json:"create_time,omitempty"`
-	StartTime   *time.Time `config:"start_time" json:"start_time,omitempty"`
-	EndTime     *time.Time `config:"end_time" json:"end_time,omitempty"`
+	ID           string     `config:"id" json:"id,omitempty"`
+	Group        string     `config:"group" json:"group,omitempty"`
+	Description  string     `config:"description" json:"description,omitempty"`
+	Type         string     `config:"type" json:"type,omitempty"`
+	Interval     string     `config:"interval" json:"interval,omitempty"`
+	InitialDelay string     `config:"initial_delay" json:"initial_delay,omitempty"`
+	Crontab      string     `config:"crontab" json:"crontab,omitempty"`
+	CreateTime   time.Time  `config:"create_time" json:"create_time,omitempty"`
+	StartTime    *time.Time `config:"start_time" json:"start_time,omitempty"`
+	EndTime      *time.Time `config:"end_time" json:"end_time,omitempty"`
 
 	// Ensures the task runs as a singleton, preventing duplicate executions when previous attempt is not finished.
 	Singleton bool `config:"singleton" json:"singleton,omitempty"`
@@ -232,6 +233,23 @@ var taskScheduler = chrono.NewDefaultTaskScheduler()
 var defaultInterval = time.Duration(10) * time.Second
 var started bool
 
+func getScheduleOptions(task *ScheduleTask) []chrono.Option {
+	if task == nil || task.Type != Interval || task.InitialDelay == "" {
+		return nil
+	}
+
+	initialDelay, err := time.ParseDuration(task.InitialDelay)
+	if err != nil {
+		log.Warnf("invalid initial delay for task [%s]: %s", task.ID, task.InitialDelay)
+		return nil
+	}
+	if initialDelay <= 0 {
+		return nil
+	}
+
+	return []chrono.Option{chrono.WithInitialDelay(initialDelay)}
+}
+
 func RunTasks() {
 	started = true
 	Tasks.Range(func(key, value any) bool {
@@ -254,7 +272,7 @@ func runTask(task *ScheduleTask) {
 
 	switch task.Type {
 	case Interval:
-		task1, err := taskScheduler.ScheduleAtFixedRate(task.Task, util.GetDurationOrDefault(task.Interval, defaultInterval))
+		task1, err := taskScheduler.ScheduleAtFixedRate(task.Task, util.GetDurationOrDefault(task.Interval, defaultInterval), getScheduleOptions(task)...)
 		if err != nil {
 			log.Error("failed to scheduled interval task:", task.Type, ",", task.Interval, ",", task.Description)
 		}

--- a/core/task/task_test.go
+++ b/core/task/task_test.go
@@ -1,0 +1,27 @@
+package task
+
+import "testing"
+
+func TestGetScheduleOptionsWithInitialDelay(t *testing.T) {
+	task := &ScheduleTask{
+		Type:         Interval,
+		InitialDelay: "250ms",
+	}
+
+	options := getScheduleOptions(task)
+	if len(options) != 1 {
+		t.Fatalf("expected one schedule option, got %d", len(options))
+	}
+}
+
+func TestGetScheduleOptionsSkipsInvalidDelay(t *testing.T) {
+	task := &ScheduleTask{
+		Type:         Interval,
+		InitialDelay: "invalid",
+	}
+
+	options := getScheduleOptions(task)
+	if len(options) != 0 {
+		t.Fatalf("expected no schedule options for invalid delay, got %d", len(options))
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,6 +23,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(cookie): prevent aggressive session cookie expiration #284
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
+- feat(task): support initial delay for interval tasks (test: `go test ./core/task/...`)
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,7 +23,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(cookie): prevent aggressive session cookie expiration #284
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
-- feat(task): support initial delay for interval tasks (test: `go test ./core/task/...`)
+- feat(task): support initial delay for interval tasks (test: `go test ./core/task/...`) #310
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  


### PR DESCRIPTION
## Summary
- add an explicit `initial_delay` option for interval tasks without changing their steady-state interval
- let scheduler tasks use `WithInitialDelay(...)` in addition to start-time based delays
- cover both scheduler delay resolution and task option parsing with focused task tests

## Testing
- `GO111MODULE=off go test ./core/task/...`
