### PR TITLE
feat(api): add secure transport and replay middleware helpers

### DIFF
--- a/core/api/security.go
+++ b/core/api/security.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"net/http"
+	"strings"
+
+	httprouter "infini.sh/framework/core/api/router"
+	replaysecurity "infini.sh/framework/core/security/replay"
+)
+
+type SecureTransportOptions struct {
+	TrustForwardHeaders bool
+}
+
+func RequestUsesSecureTransport(req *http.Request, options ...SecureTransportOptions) bool {
+	if req == nil {
+		return false
+	}
+	if req.TLS != nil {
+		return true
+	}
+
+	resolved := resolveSecureTransportOptions(options)
+	if !resolved.TrustForwardHeaders {
+		return false
+	}
+
+	for _, header := range []string{"X-Forwarded-Proto", "X-Forwarded-Protocol", "X-Url-Scheme"} {
+		if headerIndicatesHTTPS(req.Header.Get(header)) {
+			return true
+		}
+	}
+
+	if strings.EqualFold(strings.TrimSpace(req.Header.Get("X-Forwarded-Ssl")), "on") {
+		return true
+	}
+
+	return forwardedHeaderIndicatesHTTPS(req.Header.Get("Forwarded"))
+}
+
+func (handler Handler) RequireSecureTransport(h httprouter.Handle, options ...SecureTransportOptions) httprouter.Handle {
+	resolved := resolveSecureTransportOptions(options)
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		if !RequestUsesSecureTransport(r, resolved) {
+			handler.WriteError(w, "sensitive endpoints require HTTPS or a trusted HTTPS reverse proxy", http.StatusUpgradeRequired)
+			return
+		}
+		h(w, r, ps)
+	}
+}
+
+func RequireSecureTransport(h httprouter.Handle, options ...SecureTransportOptions) httprouter.Handle {
+	return Handler{}.RequireSecureTransport(h, options...)
+}
+
+func (handler Handler) RequireReplayProtection(h httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		if err := replaysecurity.ValidateAndConsumeReplayNonce(r); err != nil {
+			handler.WriteError(w, err.Error(), http.StatusUnauthorized)
+			return
+		}
+		h(w, r, ps)
+	}
+}
+
+func RequireReplayProtection(h httprouter.Handle) httprouter.Handle {
+	return Handler{}.RequireReplayProtection(h)
+}
+
+func resolveSecureTransportOptions(options []SecureTransportOptions) SecureTransportOptions {
+	if len(options) == 0 {
+		return SecureTransportOptions{}
+	}
+	return options[0]
+}
+
+func headerIndicatesHTTPS(value string) bool {
+	if value == "" {
+		return false
+	}
+	first := strings.TrimSpace(strings.Split(value, ",")[0])
+	return strings.EqualFold(first, "https")
+}
+
+func forwardedHeaderIndicatesHTTPS(value string) bool {
+	if value == "" {
+		return false
+	}
+
+	for _, forwardedValue := range strings.Split(value, ",") {
+		for _, token := range strings.Split(forwardedValue, ";") {
+			parts := strings.SplitN(strings.TrimSpace(token), "=", 2)
+			if len(parts) != 2 || !strings.EqualFold(parts[0], "proto") {
+				continue
+			}
+			proto := strings.Trim(parts[1], "\"")
+			return strings.EqualFold(proto, "https")
+		}
+	}
+
+	return false
+}

--- a/core/api/security_test.go
+++ b/core/api/security_test.go
@@ -1,0 +1,106 @@
+package api
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	httprouter "infini.sh/framework/core/api/router"
+	replaysecurity "infini.sh/framework/core/security/replay"
+)
+
+func TestRequestUsesSecureTransport(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(req *http.Request)
+		options []SecureTransportOptions
+		secure  bool
+	}{
+		{
+			name: "tls request",
+			setup: func(req *http.Request) {
+				req.TLS = &tls.ConnectionState{}
+			},
+			secure: true,
+		},
+		{
+			name: "forwarded proto requires opt in",
+			setup: func(req *http.Request) {
+				req.Header.Set("X-Forwarded-Proto", "https")
+			},
+			secure: false,
+		},
+		{
+			name: "forwarded proto trusted when enabled",
+			setup: func(req *http.Request) {
+				req.Header.Set("X-Forwarded-Proto", "https")
+			},
+			options: []SecureTransportOptions{{TrustForwardHeaders: true}},
+			secure:  true,
+		},
+		{
+			name:   "plain http",
+			setup:  func(req *http.Request) {},
+			secure: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "http://console.local/account/login", nil)
+			tt.setup(req)
+
+			if RequestUsesSecureTransport(req, tt.options...) != tt.secure {
+				t.Fatalf("expected secure=%v", tt.secure)
+			}
+		})
+	}
+}
+
+func TestRequireSecureTransport(t *testing.T) {
+	handler := Handler{}
+	called := false
+	protected := handler.RequireSecureTransport(func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "http://console.local/account/login", nil)
+	resp := httptest.NewRecorder()
+
+	protected(resp, req, nil)
+
+	if called {
+		t.Fatal("expected insecure request to be blocked")
+	}
+	if resp.Code != http.StatusUpgradeRequired {
+		t.Fatalf("expected status %d, got %d", http.StatusUpgradeRequired, resp.Code)
+	}
+}
+
+func TestRequireReplayProtection(t *testing.T) {
+	handler := Handler{}
+	req := httptest.NewRequest(http.MethodPost, "https://console.local/account/login", nil)
+	nonce, _, err := replaysecurity.IssueReplayNonce(req, http.MethodPost, "/account/login")
+	if err != nil {
+		t.Fatalf("issue replay nonce: %v", err)
+	}
+	req.Header.Set(replaysecurity.HeaderName, nonce)
+
+	called := false
+	protected := handler.RequireReplayProtection(func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+	resp := httptest.NewRecorder()
+
+	protected(resp, req, nil)
+
+	if !called {
+		t.Fatal("expected replay-protected handler to run")
+	}
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, resp.Code)
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -24,6 +24,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
 - feat(security): add replay nonce helpers for sensitive requests (test: `go test ./core/security/replay`) #312
+- feat(api): add secure transport and replay middleware helpers (test: `go test ./core/api`) 
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -24,7 +24,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
 - feat(security): add replay nonce helpers for sensitive requests (test: `go test ./core/security/replay`) #312
-- feat(api): add secure transport and replay middleware helpers (test: `go test ./core/api`) 
+- feat(api): add secure transport and replay middleware helpers (test: `go test ./core/api`) #313
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  


### PR DESCRIPTION
## Summary
- add helpers to detect whether a request is using HTTPS or a trusted HTTPS reverse proxy
- add API middleware wrappers for secure-transport enforcement and replay-nonce validation
- cover transport detection and replay middleware behavior with focused API tests

## Testing
- `go test ./core/api` *(currently blocked on main by pre-existing missing generated symbols: `cfg.LastFrameworkCommitLog` and `cfg.LastFrameworkVendorCommitLog` in `core/env/env.go`)*
