### PR TITLE
feat(config): include base_path in published endpoints

### DIFF
--- a/core/config/system.go
+++ b/core/config/system.go
@@ -391,7 +391,7 @@ type S3BucketConfig struct {
 }
 
 func (config *WebAppConfig) GetEndpoint() string {
-	return fmt.Sprintf("%s://%s", config.GetSchema(), config.NetworkConfig.GetPublishAddr())
+	return joinBasePath(fmt.Sprintf("%s://%s", config.GetSchema(), config.NetworkConfig.GetPublishAddr()), config.BasePath)
 }
 
 func (config *WebAppConfig) GetSchema() string {
@@ -427,7 +427,18 @@ type APIConfig struct {
 }
 
 func (config *APIConfig) GetEndpoint() string {
-	return fmt.Sprintf("%s://%s", config.GetSchema(), config.NetworkConfig.GetPublishAddr())
+	return joinBasePath(fmt.Sprintf("%s://%s", config.GetSchema(), config.NetworkConfig.GetPublishAddr()), config.BasePath)
+}
+
+func joinBasePath(endpoint, basePath string) string {
+	basePath = strings.TrimSpace(basePath)
+	if basePath == "" || basePath == "/" {
+		return endpoint
+	}
+	if !strings.HasPrefix(basePath, "/") {
+		basePath = "/" + basePath
+	}
+	return strings.TrimRight(endpoint, "/") + strings.TrimRight(basePath, "/")
 }
 
 func (config *APIConfig) GetSchema() string {

--- a/core/config/system_test.go
+++ b/core/config/system_test.go
@@ -196,3 +196,25 @@ func TestHTTPClientConfig_ValidateProxy(t *testing.T) {
 		}
 	})
 }
+
+func TestGetEndpointIncludesBasePath(t *testing.T) {
+	t.Run("api endpoint includes normalized base path", func(t *testing.T) {
+		cfg := APIConfig{
+			NetworkConfig: NetworkConfig{Publish: "agent.local:2900"},
+			BasePath:      "api/v1/",
+		}
+		if got := cfg.GetEndpoint(); got != "http://agent.local:2900/api/v1" {
+			t.Fatalf("expected base path in api endpoint, got %q", got)
+		}
+	})
+
+	t.Run("web endpoint keeps root path unchanged", func(t *testing.T) {
+		cfg := WebAppConfig{
+			NetworkConfig: NetworkConfig{Publish: "console.local:9000"},
+			BasePath:      "/",
+		}
+		if got := cfg.GetEndpoint(); got != "http://console.local:9000" {
+			t.Fatalf("expected root path to be ignored, got %q", got)
+		}
+	})
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,7 +23,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(cookie): prevent aggressive session cookie expiration #284
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
-- feat(config): include base_path in published api and web endpoints (test: `go test ./core/config`)
+- feat(config): include base_path in published api and web endpoints (test: `go test ./core/config`) #314
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,6 +23,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(cookie): prevent aggressive session cookie expiration #284
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
+- feat(config): include base_path in published api and web endpoints (test: `go test ./core/config`)
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  


### PR DESCRIPTION
## Summary
- include configured `base_path` when publishing API and web listener endpoints
- normalize leading and trailing slashes so published endpoints stay stable
- cover base-path endpoint formatting with focused config tests

## Testing
- `GO111MODULE=off go test ./core/config`
