### PR TITLE
feat(config): order section callbacks before generic reload hooks

### DIFF
--- a/core/config/fs_watcher.go
+++ b/core/config/fs_watcher.go
@@ -62,6 +62,36 @@ func loadConfigFile(file string) *Config {
 	return nil
 }
 
+func dispatchConfigChangeEvent(ev fsnotify.Event, watcherCallbacks []CallbackFunc) {
+	for _, v := range watcherCallbacks {
+		v(ev.Name, ev.Op)
+	}
+
+	cfg := loadConfigFile(ev.Name)
+	if cfg != nil {
+		for _, k := range sectionCallbackOrder {
+			callbacks, ok := sectionCallbacks[k]
+			if !ok || !cfg.HasField(k) {
+				continue
+			}
+			currentCfg, err := cfg.Child(k, -1)
+			if err != nil {
+				log.Error(err)
+				continue
+			}
+			previousCfg, _ := latestConfig[k]
+			for _, f := range callbacks {
+				f(previousCfg, currentCfg)
+			}
+			latestConfig[k] = currentCfg
+		}
+	}
+
+	for _, v := range configCallbacks {
+		v(ev)
+	}
+}
+
 var validExtensions = []string{".yml", ".yaml", ".tpl"}
 
 func SetValidExtension(v []string) {
@@ -153,40 +183,7 @@ func AddPathToWatch(path string, callback CallbackFunc) {
 				time.Sleep(2 * time.Second)
 				log.Trace("2 seconds out, on:", ev.String())
 
-				// AddPathToWatch
-
-				for _, v := range watcher.callbacks {
-					v(ev.Name, ev.Op)
-				}
-
-				// NotifyOnConfigChange
-
-				for _, v := range configCallbacks {
-					v(ev)
-				}
-
-				// NotifyOnConfigSectionChange
-
-				cfg := loadConfigFile(ev.Name)
-				if cfg == nil {
-					continue
-				}
-
-				for k, v := range sectionCallbacks {
-					if cfg.HasField(k) {
-						currentCfg, err := cfg.Child(k, -1)
-						if err != nil {
-							log.Error(err)
-							continue
-						}
-						// diff config
-						previousCfg, _ := latestConfig[k]
-						for _, f := range v {
-							f(previousCfg, currentCfg)
-						}
-						latestConfig[k] = currentCfg
-					}
-				}
+				dispatchConfigChangeEvent(ev, watcher.callbacks)
 			}
 		}()
 	})
@@ -255,11 +252,13 @@ func StopWatchers() {
 }
 
 var sectionCallbacks = map[string][]func(pCfg, cCfg *Config){}
+var sectionCallbackOrder = []string{}
 var configCallbacks = []func(fsnotify.Event){}
 var cfgLocker = sync.RWMutex{}
 
 // NotifyOnConfigSectionChange will trigger callback when any configuration file change detected and
-// configKey present in the changed file
+// configKey present in the changed file. Section callbacks run before generic NotifyOnConfigChange
+// callbacks so section-scoped state can be refreshed before dependent consumers reload.
 func NotifyOnConfigSectionChange(configKey string, f func(pCfg, cCfg *Config)) {
 	cfgLocker.Lock()
 	defer cfgLocker.Unlock()
@@ -268,12 +267,14 @@ func NotifyOnConfigSectionChange(configKey string, f func(pCfg, cCfg *Config)) {
 	if !ok {
 		v = []func(pCfg, cCfg *Config){}
 		sectionCallbacks[configKey] = v
+		sectionCallbackOrder = append(sectionCallbackOrder, configKey)
 	}
 	v = append(v, f)
 	sectionCallbacks[configKey] = v
 }
 
-// NotifyOnConfigChange will trigger callback when any configuration file change detected
+// NotifyOnConfigChange will trigger callback when any configuration file change detected, after any
+// matching NotifyOnConfigSectionChange callbacks for the same event have run.
 func NotifyOnConfigChange(f func(fsnotify.Event)) {
 	cfgLocker.Lock()
 	defer cfgLocker.Unlock()

--- a/core/config/fs_watcher_test.go
+++ b/core/config/fs_watcher_test.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestDispatchConfigChangeEventRunsSectionCallbacksBeforeGenericCallbacks(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "generated_metrics_tasks.yml")
+	content := []byte("elasticsearch:\n  - id: \"cluster-1\"\n    name: \"cluster-1\"\n    enabled: true\n    endpoint: \"http://127.0.0.1:9200\"\n")
+	if err := os.WriteFile(file, content, 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	previousSections := sectionCallbacks
+	previousOrder := sectionCallbackOrder
+	previousConfigs := configCallbacks
+	previousLatest := latestConfig
+	sectionCallbacks = map[string][]func(pCfg, cCfg *Config){}
+	sectionCallbackOrder = nil
+	configCallbacks = nil
+	latestConfig = map[string]*Config{}
+	t.Cleanup(func() {
+		sectionCallbacks = previousSections
+		sectionCallbackOrder = previousOrder
+		configCallbacks = previousConfigs
+		latestConfig = previousLatest
+	})
+
+	var order []string
+	NotifyOnConfigSectionChange("elasticsearch", func(pCfg, cCfg *Config) {
+		order = append(order, "section")
+	})
+	NotifyOnConfigChange(func(ev fsnotify.Event) {
+		order = append(order, "generic")
+	})
+
+	dispatchConfigChangeEvent(fsnotify.Event{Name: file, Op: fsnotify.Write}, nil)
+
+	if len(order) != 2 {
+		t.Fatalf("expected 2 callbacks, got %d (%v)", len(order), order)
+	}
+	if order[0] != "section" || order[1] != "generic" {
+		t.Fatalf("expected section callback before generic callback, got %v", order)
+	}
+}
+
+func TestDispatchConfigChangeEventRunsSectionCallbacksInRegistrationOrder(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "gateway.yml")
+	content := []byte("flow:\n  - name: flow-1\nrouter:\n  - name: router-1\nentry:\n  - name: entry-1\n")
+	if err := os.WriteFile(file, content, 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	previousSections := sectionCallbacks
+	previousOrder := sectionCallbackOrder
+	previousConfigs := configCallbacks
+	previousLatest := latestConfig
+	sectionCallbacks = map[string][]func(pCfg, cCfg *Config){}
+	sectionCallbackOrder = nil
+	configCallbacks = nil
+	latestConfig = map[string]*Config{}
+	t.Cleanup(func() {
+		sectionCallbacks = previousSections
+		sectionCallbackOrder = previousOrder
+		configCallbacks = previousConfigs
+		latestConfig = previousLatest
+	})
+
+	var order []string
+	NotifyOnConfigSectionChange("flow", func(pCfg, cCfg *Config) {
+		order = append(order, "flow")
+	})
+	NotifyOnConfigSectionChange("router", func(pCfg, cCfg *Config) {
+		order = append(order, "router")
+	})
+	NotifyOnConfigSectionChange("entry", func(pCfg, cCfg *Config) {
+		order = append(order, "entry")
+	})
+
+	dispatchConfigChangeEvent(fsnotify.Event{Name: file, Op: fsnotify.Write}, nil)
+
+	expected := []string{"flow", "router", "entry"}
+	if len(order) != len(expected) {
+		t.Fatalf("expected %d callbacks, got %d (%v)", len(expected), len(order), order)
+	}
+	for i, want := range expected {
+		if order[i] != want {
+			t.Fatalf("expected callback order %v, got %v", expected, order)
+		}
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,7 +23,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(cookie): prevent aggressive session cookie expiration #284
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
-- feat(config): run section config callbacks before generic reload hooks (test: `go test ./core/config`)
+- feat(config): run section config callbacks before generic reload hooks (test: `go test ./core/config`) #315
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -23,6 +23,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(cookie): prevent aggressive session cookie expiration #284
 - feat(client): support token-based authorization #288
 - feat: add pluggable sink to host metrics collectors #288
+- feat(config): run section config callbacks before generic reload hooks (test: `go test ./core/config`)
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  


### PR DESCRIPTION
## Summary
- run section-scoped config callbacks before generic config reload hooks
- preserve section callback execution order based on registration order
- cover callback ordering with focused config watcher tests

## Testing
- `GO111MODULE=off go test ./core/config`
