### PR TITLE
feat(config): add websocket max message size setting

### DIFF
--- a/core/config/system.go
+++ b/core/config/system.go
@@ -487,6 +487,7 @@ type WebsocketConfig struct {
 	EchoWelcomeMessageOnConnect bool     `config:"echo_welcome_message_on_connect"`
 	EchoLoggingConfigOnConnect  bool     `config:"echo_logging_config_on_connect"`
 	BasePath                    string   `config:"base_path"`
+	MaxMessageSizeBytes         int64    `config:"max_message_size_bytes"`
 	PermittedHosts              []string `config:"permitted_hosts"`
 	SkipHostVerify              bool     `config:"skip_host_verify"`
 }

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -28,6 +28,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(reverse): add shared reverse websocket protocol helpers (test: `go test ./core/api/websocket/reverse`) #303
 - feat(reverse): add reverse websocket session manager (test: `go test ./core/api/websocket/reverse`) #304
 - feat(api): expose registered API/UI handlers for in-process dispatch (test: `go test ./core/api`) #305
+- feat(config): add websocket max message size setting (test: `go test ./core/config`)
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -28,7 +28,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat(reverse): add shared reverse websocket protocol helpers (test: `go test ./core/api/websocket/reverse`) #303
 - feat(reverse): add reverse websocket session manager (test: `go test ./core/api/websocket/reverse`) #304
 - feat(api): expose registered API/UI handlers for in-process dispatch (test: `go test ./core/api`) #305
-- feat(config): add websocket max message size setting (test: `go test ./core/config`)
+- feat(config): add websocket max message size setting (test: `go test ./core/config`) #316
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- add `max_message_size_bytes` to websocket config so websocket handlers can read a configured size limit
- keep the setting in the shared config struct used by API websocket initialization
- provide the config plumbing needed by the websocket size limit PR

## Testing
- `GO111MODULE=off go test ./core/config`
