### PR TITLE
chore(task): reduce startup ORM handler error noise

### DIFF
--- a/core/orm/registry.go
+++ b/core/orm/registry.go
@@ -35,6 +35,10 @@ func InitSchema() error {
 
 var handler ORM
 
+func HasHandler() bool {
+	return handler != nil
+}
+
 func getHandler() ORM {
 	if handler == nil {
 		panic(errors.New("ORM handler is not registered"))

--- a/core/orm/registry_test.go
+++ b/core/orm/registry_test.go
@@ -1,0 +1,52 @@
+package orm
+
+import "testing"
+
+type handlerProbeORM struct{}
+
+func (handlerProbeORM) Count(o interface{}, query interface{}) (int64, error) { return 0, nil }
+func (handlerProbeORM) GroupBy(o interface{}, selectField, groupField string, haveQuery string, haveValue interface{}) (error, map[string]interface{}) {
+	return nil, nil
+}
+func (handlerProbeORM) GetIndexName(o interface{}) string { return "" }
+func (handlerProbeORM) GetWildcardIndexName(o interface{}) string {
+	return ""
+}
+func (handlerProbeORM) GetBy(field string, value interface{}, o interface{}) (error, Result) {
+	return nil, Result{}
+}
+func (handlerProbeORM) DeleteBy(o interface{}, query interface{}) error { return nil }
+func (handlerProbeORM) UpdateBy(o interface{}, query interface{}) error { return nil }
+func (handlerProbeORM) Search(o interface{}, q *Query) (error, Result)  { return nil, Result{} }
+func (handlerProbeORM) SearchWithResultItemMapper(resultArrayRef interface{}, itemMapFunc func(source map[string]interface{}, targetRef interface{}) error, q *Query) (error, *SimpleResult) {
+	return nil, &SimpleResult{}
+}
+func (handlerProbeORM) SearchV2(ctx *Context, qb *QueryBuilder) (*SearchResult, error) {
+	return &SearchResult{}, nil
+}
+func (handlerProbeORM) DeleteByQuery(ctx *Context, qb *QueryBuilder) (*DeleteByQueryResponse, error) {
+	return &DeleteByQueryResponse{}, nil
+}
+func (handlerProbeORM) RegisterSchemaWithName(t interface{}, customizedName string) error { return nil }
+func (handlerProbeORM) Save(ctx *Context, o interface{}) error                            { return nil }
+func (handlerProbeORM) Create(ctx *Context, o interface{}) error                          { return nil }
+func (handlerProbeORM) Update(ctx *Context, o interface{}) error                          { return nil }
+func (handlerProbeORM) Delete(ctx *Context, o interface{}) error                          { return nil }
+func (handlerProbeORM) Get(ctx *Context, o interface{}) (bool, error)                     { return false, nil }
+
+func TestHasHandlerReportsRegistrationState(t *testing.T) {
+	original := handler
+	handler = nil
+	t.Cleanup(func() {
+		handler = original
+	})
+
+	if HasHandler() {
+		t.Fatal("expected HasHandler to be false when no ORM handler is registered")
+	}
+
+	handler = handlerProbeORM{}
+	if !HasHandler() {
+		t.Fatal("expected HasHandler to be true after an ORM handler is registered")
+	}
+}

--- a/core/task/task.go
+++ b/core/task/task.go
@@ -28,15 +28,33 @@ import (
 	log "github.com/cihub/seelog"
 	"infini.sh/framework/core/errors"
 	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/orm"
 	"infini.sh/framework/core/task/chrono"
 	"infini.sh/framework/core/util"
 	"runtime"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 )
 
 var Tasks = sync.Map{}
+
+func shouldSilenceStartupTaskError(msg string) bool {
+	return !orm.HasHandler() && strings.Contains(msg, "ORM handler is not registered")
+}
+
+func logTaskRuntimeIssue(msg string, raw interface{}) {
+	if shouldSilenceStartupTaskError(msg) {
+		log.Debug(msg)
+		return
+	}
+	if raw != nil {
+		log.Error(raw, msg)
+		return
+	}
+	log.Error(msg)
+}
 
 type State string
 
@@ -103,7 +121,7 @@ func RegisterTransientTask(group, tag string, f func(ctx context.Context) error,
 					case string:
 						v = r.(string)
 					}
-					log.Error(r, v)
+					logTaskRuntimeIssue(v, r)
 				}
 			}
 			task.State = Finished
@@ -118,7 +136,7 @@ func RegisterTransientTask(group, tag string, f func(ctx context.Context) error,
 		task.State = Running
 		err := inner(innerCtx)
 		if err != nil {
-			log.Error(err)
+			logTaskRuntimeIssue(err.Error(), err)
 		}
 		t = time.Now()
 		task.EndTime = &t
@@ -194,7 +212,7 @@ func RegisterScheduleTask(task ScheduleTask) (taskID string) {
 						case string:
 							v = r.(string)
 						}
-						log.Error(v)
+						logTaskRuntimeIssue(v, nil)
 					}
 				}
 				task.isTaskRunning.Store(false)

--- a/core/task/task_test.go
+++ b/core/task/task_test.go
@@ -1,0 +1,15 @@
+package task
+
+import "testing"
+
+func TestShouldSilenceStartupTaskErrorWithoutORMHandler(t *testing.T) {
+	if !shouldSilenceStartupTaskError("ORM handler is not registered") {
+		t.Fatal("expected missing ORM handler startup error to be silenced")
+	}
+}
+
+func TestShouldSilenceStartupTaskErrorIgnoresOtherMessages(t *testing.T) {
+	if shouldSilenceStartupTaskError("failed to scheduled interval task") {
+		t.Fatal("expected unrelated task error to keep normal logging")
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- chore(task): reduce startup ORM handler error noise (test: `GO111MODULE=off go test ./core/orm ./core/task/...`) #317
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- add `orm.HasHandler()` so task runtime code can detect startup-before-ORM initialization
- downgrade the expected "ORM handler is not registered" startup task noise to debug logging
- add focused orm/task tests and release notes for the startup logging change

## Testing
- GO111MODULE=off go test ./core/orm ./core/task/...
