### PR TITLE
fix(app): use executable directory for service working directory

### DIFF
--- a/app.go
+++ b/app.go
@@ -33,6 +33,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"runtime/debug"
 	"sync"
@@ -83,6 +84,18 @@ type App struct {
 	svc     service.Service
 	exit    chan os.Signal
 	svcFlag string
+}
+
+func getServiceWorkingDirectory() string {
+	executablePath, err := os.Executable()
+	if err == nil {
+		return filepath.Dir(executablePath)
+	}
+	workdir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+	return workdir
 }
 
 const (
@@ -575,10 +588,7 @@ func (app *App) Run() {
 	svcOptions["SuccessExitStatus"] = "1 2 8 SIGKILL"
 	svcOptions["LimitNOFILE"] = 1024000
 
-	workdir, err := os.Getwd()
-	if err != nil {
-		panic(err)
-	}
+	workdir := getServiceWorkingDirectory()
 
 	serviceName := app.environment.GetAppLowercaseName()
 	if v, ok := os.LookupEnv(env_SERVICE_NAME); ok {

--- a/app_test.go
+++ b/app_test.go
@@ -1,0 +1,20 @@
+package framework
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGetServiceWorkingDirectoryUsesExecutableDir(t *testing.T) {
+	executablePath, err := os.Executable()
+	if err != nil {
+		t.Fatalf("failed to get executable path: %v", err)
+	}
+
+	got := getServiceWorkingDirectory()
+	want := filepath.Dir(executablePath)
+	if got != want {
+		t.Fatalf("expected service working directory %q, got %q", want, got)
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- fix(app): use executable directory for service working directory (test: `make config && go test .`) #318
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- resolve the service working directory from the executable path instead of the launch shell cwd
- keep the existing cwd fallback only for cases where the executable path cannot be resolved
- add a focused root package test and release note for the service working-directory fix

## Testing
- go test .
