### PR TITLE
fix: harden disk queue writes on slow disks

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -25,6 +25,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add pluggable sink to host metrics collectors #288
 
 ### 🐛 Bug fix  
+- fix: make disk queue writes more tolerant of slow disks and queue backlog #320
 ### ✈️ Improvements  
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249

--- a/modules/queue/disk_queue/diskqueue.go
+++ b/modules/queue/disk_queue/diskqueue.go
@@ -69,6 +69,8 @@ import (
 	"infini.sh/framework/core/util/zstd"
 )
 
+const bytesPerMiB = 1024 * 1024
+
 // providing a filesystem backed FIFO queue
 type DiskBasedQueue struct {
 	sync.RWMutex
@@ -118,6 +120,8 @@ type DiskBasedQueue struct {
 // NewDiskQueue instantiates a new instance of DiskBasedQueue, retrieving metadata
 // from the filesystem and starting the read ahead goroutine
 func NewDiskQueueByConfig(name, dataPath string, cfg *DiskQueueConfig) *DiskBasedQueue {
+	normalizeDiskQueueConfig(cfg)
+
 	d := DiskBasedQueue{
 		name:               name,
 		dataPath:           dataPath,
@@ -177,7 +181,8 @@ func (d *DiskBasedQueue) ReadChan() <-chan []byte {
 
 // Put writes a []byte to the queue
 func (d *DiskBasedQueue) Put(data []byte) WriteResponse {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(d.cfg.WriteTimeoutInMS)*time.Millisecond)
+	writeTimeout := d.getWriteTimeout(len(data))
+	ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
 	defer cancel()
 
 	size := int64(len(data))
@@ -232,7 +237,7 @@ func (d *DiskBasedQueue) Put(data []byte) WriteResponse {
 		switch res.Error {
 		case context.DeadlineExceeded:
 			// Handle timeout error specifically
-			res.Error = fmt.Errorf("operation timed out: %w", res.Error)
+			res.Error = fmt.Errorf("operation timed out after %s waiting for disk queue writer availability: %w", writeTimeout, res.Error)
 		case context.Canceled:
 			// Handle cancellation error specifically
 			res.Error = fmt.Errorf("operation was canceled: %w", res.Error)
@@ -242,6 +247,28 @@ func (d *DiskBasedQueue) Put(data []byte) WriteResponse {
 		}
 		return res
 	}
+}
+
+func (d *DiskBasedQueue) getWriteTimeout(payloadSize int) time.Duration {
+	timeoutInMS := defaultWriteTimeoutInMS
+	if d != nil && d.cfg != nil && d.cfg.WriteTimeoutInMS > 0 {
+		timeoutInMS = d.cfg.WriteTimeoutInMS
+	}
+
+	if payloadSize > 0 {
+		payloadMiB := int64((payloadSize + bytesPerMiB - 1) / bytesPerMiB)
+		timeoutInMS += payloadMiB * adaptiveWriteTimeoutPerPayloadMiBInMS
+	}
+
+	if d != nil && len(d.writeChan) > 0 {
+		timeoutInMS += int64(len(d.writeChan)) * adaptiveWriteTimeoutPerQueuedWriteInMS
+	}
+
+	if timeoutInMS > maxAdaptiveWriteTimeoutInMS {
+		timeoutInMS = maxAdaptiveWriteTimeoutInMS
+	}
+
+	return time.Duration(timeoutInMS) * time.Millisecond
 }
 
 // Close cleans up the queue and persists metadata

--- a/modules/queue/disk_queue/diskqueue_test.go
+++ b/modules/queue/disk_queue/diskqueue_test.go
@@ -1,0 +1,40 @@
+package queue
+
+import (
+	"testing"
+	"time"
+)
+
+func TestGetWriteTimeoutIncludesPayloadAndBacklog(t *testing.T) {
+	dq := &DiskBasedQueue{
+		cfg:       &DiskQueueConfig{WriteTimeoutInMS: defaultWriteTimeoutInMS},
+		writeChan: make(chan []byte, defaultWriteChanBuffer),
+	}
+
+	dq.writeChan <- []byte("a")
+	dq.writeChan <- []byte("b")
+
+	timeout := dq.getWriteTimeout(3 * bytesPerMiB)
+
+	expected := time.Duration(defaultWriteTimeoutInMS+3*adaptiveWriteTimeoutPerPayloadMiBInMS+2*adaptiveWriteTimeoutPerQueuedWriteInMS) * time.Millisecond
+	if timeout != expected {
+		t.Fatalf("unexpected write timeout: got %s want %s", timeout, expected)
+	}
+}
+
+func TestGetWriteTimeoutCapsAtMaximum(t *testing.T) {
+	dq := &DiskBasedQueue{
+		cfg:       &DiskQueueConfig{WriteTimeoutInMS: defaultWriteTimeoutInMS},
+		writeChan: make(chan []byte, defaultWriteChanBuffer),
+	}
+
+	for i := 0; i < cap(dq.writeChan); i++ {
+		dq.writeChan <- []byte("x")
+	}
+
+	timeout := dq.getWriteTimeout(64 * bytesPerMiB)
+	expected := time.Duration(maxAdaptiveWriteTimeoutInMS) * time.Millisecond
+	if timeout != expected {
+		t.Fatalf("unexpected capped timeout: got %s want %s", timeout, expected)
+	}
+}

--- a/modules/queue/disk_queue/module.go
+++ b/modules/queue/disk_queue/module.go
@@ -124,7 +124,32 @@ type CompressConfig struct {
 	Level   int  `config:"level"`
 }
 
+const (
+	defaultWriteTimeoutInMS                int64 = 60 * 1000
+	defaultWriteChanBuffer                       = 16
+	minRecommendedWriteTimeoutInMS         int64 = 15 * 1000
+	maxAdaptiveWriteTimeoutInMS            int64 = 5 * 60 * 1000
+	adaptiveWriteTimeoutPerQueuedWriteInMS int64 = 3 * 1000
+	adaptiveWriteTimeoutPerPayloadMiBInMS  int64 = 5 * 1000
+)
+
 var preventRead bool
+
+func normalizeDiskQueueConfig(cfg *DiskQueueConfig) {
+	if cfg == nil {
+		return
+	}
+
+	if cfg.WriteTimeoutInMS <= 0 {
+		cfg.WriteTimeoutInMS = defaultWriteTimeoutInMS
+	} else if cfg.WriteTimeoutInMS < minRecommendedWriteTimeoutInMS {
+		log.Warnf("disk_queue write timeout may be too small on slow disks: %dms", cfg.WriteTimeoutInMS)
+	}
+
+	if cfg.WriteChanBuffer <= 0 {
+		cfg.WriteChanBuffer = defaultWriteChanBuffer
+	}
+}
 
 func checkCapacity(cfg *DiskQueueConfig) error {
 
@@ -233,14 +258,14 @@ func (module *DiskQueue) Setup() {
 		MinMsgSize:                      1,
 		MaxMsgSize:                      104857600,         //100MB
 		MaxBytesPerFile:                 100 * 1024 * 1024, //100MB
-		WriteTimeoutInMS:                1000,              //1s
-		CheckDiskCapacityRetryDelayInMs: 10 * 000,          //10s
+		WriteTimeoutInMS:                defaultWriteTimeoutInMS,
+		CheckDiskCapacityRetryDelayInMs: 10 * 000, //10s
 		EOFRetryDelayInMs:               500,
 		SyncEveryRecords:                1000,
 		SyncTimeoutInMS:                 1000,
 		NotifyChanBuffer:                100,
 		ReadChanBuffer:                  0,
-		WriteChanBuffer:                 0,
+		WriteChanBuffer:                 defaultWriteChanBuffer,
 		WarningFreeBytes:                10 * 1024 * 1024 * 1024,
 		ReservedFreeBytes:               5 * 1024 * 1024 * 1024,
 		PrepareFilesToRead:              true,
@@ -261,6 +286,8 @@ func (module *DiskQueue) Setup() {
 	if ok && err != nil && global.Env().SystemConfig.Configs.PanicOnConfigError {
 		panic(err)
 	}
+
+	normalizeDiskQueueConfig(module.cfg)
 
 	if !module.cfg.Enabled {
 		return

--- a/modules/queue/disk_queue/module_test.go
+++ b/modules/queue/disk_queue/module_test.go
@@ -1,0 +1,32 @@
+package queue
+
+import "testing"
+
+func TestNormalizeDiskQueueConfigAppliesRobustWriteDefaults(t *testing.T) {
+	cfg := &DiskQueueConfig{}
+
+	normalizeDiskQueueConfig(cfg)
+
+	if cfg.WriteTimeoutInMS != defaultWriteTimeoutInMS {
+		t.Fatalf("unexpected write timeout: %d", cfg.WriteTimeoutInMS)
+	}
+	if cfg.WriteChanBuffer != defaultWriteChanBuffer {
+		t.Fatalf("unexpected write chan buffer: %d", cfg.WriteChanBuffer)
+	}
+}
+
+func TestNormalizeDiskQueueConfigKeepsExplicitWriteSettings(t *testing.T) {
+	cfg := &DiskQueueConfig{
+		WriteTimeoutInMS: 45 * 1000,
+		WriteChanBuffer:  64,
+	}
+
+	normalizeDiskQueueConfig(cfg)
+
+	if cfg.WriteTimeoutInMS != 45*1000 {
+		t.Fatalf("write timeout should be preserved, got %d", cfg.WriteTimeoutInMS)
+	}
+	if cfg.WriteChanBuffer != 64 {
+		t.Fatalf("write chan buffer should be preserved, got %d", cfg.WriteChanBuffer)
+	}
+}


### PR DESCRIPTION
## Summary
- increase disk queue write tolerance for slow disks and queued write backlog
- normalize disk queue write timeout and write channel defaults before queue startup
- add focused disk queue tests and release notes for the slow-disk hardening change

## Testing
- go test ./modules/queue/disk_queue
