### PR TITLE
chore: reduce queue and metrics debug log noise

### DIFF
--- a/core/env/env.go
+++ b/core/env/env.go
@@ -550,7 +550,7 @@ func ParseConfigSection(cfg *config.Config, configKey string, configInstance int
 		// go-ucfg raises an error if the key does not exist, in which case
 		// we should return and report that the configKey does not exist.
 		if ucfgErr, ok := err.(ucfg.Error); ok && ucfgErr.Reason() == ucfg.ErrMissing {
-			log.Debugf("config key: %s not found", configKey)
+			log.Tracef("config key: %s not found", configKey)
 			return false, nil
 		}
 

--- a/core/queue/consumer_config.go
+++ b/core/queue/consumer_config.go
@@ -172,7 +172,7 @@ func RemoveAllConsumers(qConfig *QueueConfig) (bool, error) {
 		log.Error(err)
 		return false, err
 	}
-	log.Debugf("success delete all consumers for queue:%v", qConfig.ID)
+	log.Tracef("success delete all consumers for queue:%v", qConfig.ID)
 	return true, nil
 }
 

--- a/core/queue/queue_config.go
+++ b/core/queue/queue_config.go
@@ -118,7 +118,7 @@ func RegisterConfig(cfg *QueueConfig) (preExists bool, err error) {
 
 	cfg.Created = time.Now().String()
 
-	log.Debug("init new queue config:", cfg.ID, ",", cfg.Name)
+	log.Trace("init new queue config:", cfg.ID, ",", cfg.Name)
 
 	addCfgToCache(cfg)
 

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- chore: reduce queue and metrics debug log noise #321
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/modules/metrics/metrics.go
+++ b/modules/metrics/metrics.go
@@ -171,7 +171,7 @@ func (module *MetricsModule) CollectAgentMetric() {
 				Type:        "interval",
 				Interval:    "10s",
 				Task: func(ctx context.Context) {
-					log.Debug("collecting instance metrics")
+					log.Trace("collecting instance metrics")
 					agentM.Collect()
 				},
 			}
@@ -202,7 +202,7 @@ func (module *MetricsModule) CollectHostMetric() {
 			Type:        "interval",
 			Interval:    "10s",
 			Task: func(ctx context.Context) {
-				log.Debug("collecting network metrics")
+				log.Trace("collecting network metrics")
 				netM.Collect()
 			},
 		}

--- a/modules/queue/disk_queue/cleanup.go
+++ b/modules/queue/disk_queue/cleanup.go
@@ -92,7 +92,7 @@ func (module *DiskQueue) deleteUnusedFiles(queueID string, fileNum int64) {
 	fileStartToDelete := fileNum - module.cfg.Retention.MaxNumOfLocalFiles
 
 	if fileStartToDelete <= 0 || consumers <= 0 || eSegmentNum < 0 {
-		log.Debugf("queue: %v, no consumers or consumer/s3 already ahead of this file, %v, %v, %v", queueID, fileStartToDelete, consumers, eSegmentNum)
+		log.Tracef("queue: %v, no consumers or consumer/s3 already ahead of this file, %v, %v, %v", queueID, fileStartToDelete, consumers, eSegmentNum)
 		return
 	}
 

--- a/modules/queue/disk_queue/compress.go
+++ b/modules/queue/disk_queue/compress.go
@@ -104,7 +104,7 @@ func (module *DiskQueue) compressFiles(queueID string, fileNum int64) {
 
 	//skip compress file
 	if fileStartToCompress <= 0 || (module.cfg.SkipZeroConsumers && consumers <= 0) || fileStartToCompress <= lastCompressedFileNum {
-		log.Debugf("skip compress %v", queueID)
+		log.Tracef("skip compress %v", queueID)
 		return
 	}
 

--- a/modules/queue/disk_queue/consumer.go
+++ b/modules/queue/disk_queue/consumer.go
@@ -236,7 +236,7 @@ READ_MSG:
 		}
 		return messages, false, err
 	}
-	log.Debugf("queue:%v, offset:%v,%v, msgSize:%v", d.queue, d.segment, d.readPos, msgSize)
+	log.Tracef("queue:%v, offset:%v,%v, msgSize:%v", d.queue, d.segment, d.readPos, msgSize)
 	if int32(msgSize) < d.mCfg.MinMsgSize || int32(msgSize) > d.mCfg.MaxMsgSize {
 		//current have changes, reload file with new position
 		newFileSize := d.getFileSize()
@@ -332,9 +332,9 @@ READ_MSG:
 			//still working on the same file
 			if d.diskQueue.writeSegmentNum == d.segment {
 				time.Sleep(100 * time.Millisecond) // Prevent catching up too quickly.
-				log.Debugf("invalid message size detected. this might be due to a dirty read as the file was being written while open. reloading segment: %d", d.segment)
+				log.Tracef("invalid message size detected. this might be due to a dirty read as the file was being written while open. reloading segment: %d", d.segment)
 			} else {
-				log.Debugf("invalid message size detected. this might be due to a partial file load. reloading segment: %d", d.segment)
+				log.Tracef("invalid message size detected. this might be due to a partial file load. reloading segment: %d", d.segment)
 			}
 
 			d.readPos = previousPos

--- a/plugins/elastic/bulk_indexing/bulk_indexing.go
+++ b/plugins/elastic/bulk_indexing/bulk_indexing.go
@@ -320,7 +320,9 @@ func (processor *BulkIndexingProcessor) Process(c *pipeline.Context) error {
 		}
 	} else {
 		cfgs := queue.GetConfigBySelector(&processor.config.Selector)
-		log.Debugf("filter queue by:%v, num of queues:%v", processor.config.Selector.ToString(), len(cfgs))
+		if global.Env().IsDebug {
+			log.Tracef("filter queue by:%v, num of queues:%v", processor.config.Selector.ToString(), len(cfgs))
+		}
 		for _, v := range cfgs {
 			if global.Env().IsDebug {
 				log.Tracef("checking queue: %v", v)
@@ -470,7 +472,7 @@ func (processor *BulkIndexingProcessor) NewBulkWorker(parentContext *pipeline.Co
 			continue
 		} else {
 			var workerID = util.GetUUID()
-			log.Debugf("starting worker:[%v], queue:[%v], slice_id:%v, host:[%v]", workerID, qConfig.Name, sliceID, preferedHost)
+			log.Tracef("starting worker:[%v], queue:[%v], slice_id:%v, host:[%v]", workerID, qConfig.Name, sliceID, preferedHost)
 
 			ctx1 := &pipeline.Context{}
 			ctx1.Set("key", key)
@@ -681,7 +683,9 @@ func (processor *BulkIndexingProcessor) NewSlicedBulkWorker(ctx *pipeline.Contex
 				log.Errorf("should not submit this bulk request, worker[%v], queue:[%v], slice:[%v], offset:[%v]->[%v],%v, msg:%v", workerID, qConfig.ID, sliceID, committedOffset, offset, err, mainBuf.GetMessageCount())
 			}
 		}
-		log.Debugf("exit worker[%v], message count[%d], queue:[%v], slice_id:%v", workerID, mainBuf.GetMessageCount(), qConfig.ID, sliceID)
+		if global.Env().IsDebug {
+			log.Tracef("exit worker[%v], message count[%d], queue:[%v], slice_id:%v", workerID, mainBuf.GetMessageCount(), qConfig.ID, sliceID)
+		}
 	}()
 
 	if global.Env().IsDebug {
@@ -798,7 +802,13 @@ READ_DOCS:
 		consumerConfig.KeepActive()
 		messages, timeout, err := consumerInstance.FetchMessages(ctx1, consumerConfig.FetchMaxMessages)
 		stats.IncrementBy("queue", qConfig.ID+".msg_fetched_from_queue", int64(len(messages)))
-		log.Debugf("slice worker, worker:[%v], [%v][%v][%v][%v] fetched message:%v,ctx:%v,timeout:%v,err:%v", workerID, qConfig.Name, consumerConfig.Group, consumerConfig.Name, sliceID, len(messages), ctx1.String(), timeout, err)
+		if err != nil || len(messages) > 0 {
+			if qConfig.Name == "bulk_requests" {
+				log.Tracef("slice worker, worker:[%v], [%v][%v][%v][%v] fetched message:%v,ctx:%v,timeout:%v,err:%v", workerID, qConfig.Name, consumerConfig.Group, consumerConfig.Name, sliceID, len(messages), ctx1.String(), timeout, err)
+			} else {
+				log.Debugf("slice worker, worker:[%v], [%v][%v][%v][%v] fetched message:%v,ctx:%v,timeout:%v,err:%v", workerID, qConfig.Name, consumerConfig.Group, consumerConfig.Name, sliceID, len(messages), ctx1.String(), timeout, err)
+			}
+		}
 		if err != nil {
 			if strings.Contains(err.Error(), "dirty_read") || err.Error() == "EOF" || err.Error() == "unexpected EOF" {
 				ctx.CancelTask()
@@ -949,7 +959,7 @@ READ_DOCS:
 							if offset != nil && committedOffset != nil && !offset.Equals(*committedOffset) {
 								err := consumerInstance.CommitOffset(*offset)
 								if err != nil {
-									log.Errorf("🔧 offset commit failed, worker:[%v], queue:[%v], slice:[%v], offset:[%v], err:%v", workerID, qConfig.Name, sliceID, *offset, err)
+									log.Errorf("offset commit failed, worker:[%v], queue:[%v], slice:[%v], offset:[%v], err:%v", workerID, qConfig.Name, sliceID, *offset, err)
 									panic(err)
 								}
 
@@ -958,11 +968,11 @@ READ_DOCS:
 								}
 								// fix: update committedOffset immediately after successful commit, to ensure state consistency
 								committedOffset = offset
-								log.Debugf("🔧 offset committed successfully, worker:[%v], queue:[%v], slice:[%v], offset:[%v]", workerID, qConfig.Name, sliceID, *offset)
-							} else {
 								if global.Env().IsDebug {
-									log.Debugf("🔧 offset not changed, skip commit, worker:[%v], queue:[%v], slice:[%v], offset:[%v], committed:[%v]", workerID, qConfig.Name, sliceID, offset, committedOffset)
+									log.Tracef("offset committed, worker:[%v], queue:[%v], slice:[%v], offset:[%v]", workerID, qConfig.Name, sliceID, *offset)
 								}
+							} else {
+								// skip unchanged offset silently to avoid noisy debug logs
 							}
 							// fix: this code is moved to loop outside (line 970) to avoid updating offset in the middle of bulk submission
 							// offset = &pop.NextOffset
@@ -1002,7 +1012,7 @@ CLEAN_BUFFER:
 	}
 
 	if global.Env().IsDebug {
-		log.Debugf("cleanup buffer, queue:[%v], slice_id:%v, offset [%v]-[%v], bulk failed (host: %v, err: %v)", qConfig.ID, sliceID, committedOffset, offset, host, err)
+		log.Tracef("cleanup buffer, queue:[%v], slice_id:%v, offset [%v]-[%v], bulk failed (host: %v, err: %v)", qConfig.ID, sliceID, committedOffset, offset, host, err)
 	}
 	lastCommit = time.Now()
 	// check bulk result, if ok, then commit offset, or retry non-200 requests, or save failure offset


### PR DESCRIPTION
## Summary
- downgrade noisy queue and metrics housekeeping logs from debug to trace where they are expected in steady-state operation
- keep bulk indexing worker lifecycle logs available in debug mode while reducing default log volume
- add release notes for the queue and metrics log-noise cleanup

## Testing
- go test ./core/queue ./modules/metrics ./modules/queue/disk_queue ./plugins/elastic/bulk_indexing
