### PR TITLE
fix(queue): recover disk queue consumers after corruption skips

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -25,6 +25,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add pluggable sink to host metrics collectors #288
 
 ### 🐛 Bug fix  
+- fix(queue): recover disk queue consumers to the current tail after corruption skips (test: `go test ./modules/queue/disk_queue`) #322
 ### ✈️ Improvements  
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249

--- a/modules/queue/disk_queue/consumer.go
+++ b/modules/queue/disk_queue/consumer.go
@@ -68,6 +68,29 @@ type Consumer struct {
 	fileLoadCompleted bool
 }
 
+func (d *Consumer) parkOnEmptyTail(fileName string) error {
+	if d.readFile != nil {
+		if err := d.readFile.Close(); err != nil && !util.ContainStr(err.Error(), "already") {
+			return err
+		}
+	}
+	d.readFile = nil
+	d.reader = nil
+	d.fileName = fileName
+	d.lastFileSize = 0
+	d.maxBytesPerFileRead = 0
+	d.fileLoadCompleted = false
+	return nil
+}
+
+func (d *Consumer) waitingForTailFile() bool {
+	return d.diskQueue != nil &&
+		d.readFile == nil &&
+		d.reader == nil &&
+		d.segment == d.diskQueue.writeSegmentNum &&
+		d.readPos == 0
+}
+
 func (c *Consumer) getFileSize() int64 {
 	var err error
 	readFile, err := os.OpenFile(c.fileName, os.O_RDONLY, 0600)
@@ -144,6 +167,22 @@ READ_MSG:
 
 	// check reader
 	if d.reader == nil {
+		if d.waitingForTailFile() {
+			if d.diskQueue.writePos > 0 || util.FileExists(d.fileName) {
+				err = d.ResetOffset(d.segment, d.readPos)
+				if err != nil {
+					if strings.Contains(err.Error(), "not found") {
+						return messages, false, nil
+					}
+					return messages, false, err
+				}
+				goto READ_MSG
+			}
+			if len(messages) == 0 && d.cCfg.EOFRetryDelayInMs > 0 {
+				time.Sleep(time.Duration(d.cCfg.EOFRetryDelayInMs) * time.Millisecond)
+			}
+			return messages, false, nil
+		}
 		return messages, false, errors.New("reader is nil")
 	}
 	//read message size
@@ -274,8 +313,19 @@ READ_MSG:
 					//can't read ahead before current write file
 					if nextSegment >= d.diskQueue.writeSegmentNum {
 						log.Debugf("need to skip to next file, but next file not exists, current write segment:%v, current read segment:%v", d.diskQueue.writeSegmentNum, d.segment)
-						d.diskQueue.skipToNextRWFile(false)
+						err = d.diskQueue.skipToNextRWFile(false)
+						if err != nil {
+							return messages, false, err
+						}
 						d.diskQueue.needSync = true
+						err = d.ResetOffset(d.diskQueue.writeSegmentNum, 0)
+						if err != nil {
+							if strings.Contains(err.Error(), "not found") {
+								return messages, false, nil
+							}
+							return messages, false, err
+						}
+						ctx.UpdateNextOffset(d.segment, d.readPos)
 					} else {
 						//let's continue move to next file
 						nextSegment++
@@ -509,6 +559,9 @@ func (d *Consumer) ResetOffset(segment, readPos int64) error {
 	if !exists {
 		//double check, but next file exists
 		if !util.FileExists(fileName) {
+			if segment == d.diskQueue.writeSegmentNum && readPos == 0 && d.diskQueue.writePos == 0 {
+				return d.parkOnEmptyTail(fileName)
+			}
 			if d.mCfg.AutoSkipCorruptFile {
 				nextSegment := d.segment + 1
 				if nextSegment > d.diskQueue.writeSegmentNum {
@@ -518,7 +571,7 @@ func (d *Consumer) ResetOffset(segment, readPos int64) error {
 					d.qCfg.Name, d.queue, d.cCfg.Key(), d.segment, d.readPos, fileName)
 			RETRY_NEXT_FILE:
 				// there are segments in the middle
-				if nextSegment < d.diskQueue.writeSegmentNum {
+				if nextSegment <= d.diskQueue.writeSegmentNum {
 					fileName, exists, next_file_exists = SmartGetFileName(d.mCfg, d.queue, nextSegment)
 					if exists || util.FileExists(fileName) {
 						log.Debugf("retry skip to next file: %v, exists", fileName)
@@ -532,6 +585,12 @@ func (d *Consumer) ResetOffset(segment, readPos int64) error {
 						goto RETRY_NEXT_FILE
 					}
 				} else {
+					if d.diskQueue.writePos == 0 {
+						d.segment = d.diskQueue.writeSegmentNum
+						d.readPos = 0
+						d.diskQueue.UpdateSegmentConsumerInReading(d.ID, d.segment)
+						return d.parkOnEmptyTail(GetFileName(d.queue, d.segment))
+					}
 					return errors.New(fileName + " not found, next segment greater than current write segment")
 				}
 			} else {

--- a/modules/queue/disk_queue/consumer_recovery_test.go
+++ b/modules/queue/disk_queue/consumer_recovery_test.go
@@ -1,0 +1,147 @@
+package queue
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "infini.sh/framework/core/env"
+	"infini.sh/framework/core/global"
+	corequeue "infini.sh/framework/core/queue"
+)
+
+func TestResetOffsetSkipsMissingSegmentsUpToCurrentWriteSegment(t *testing.T) {
+	env1 := EmptyEnv()
+	env1.SystemConfig.PathConfig.Data = t.TempDir()
+	global.RegisterEnv(env1)
+
+	queueName := "reset-offset-skip"
+	data := []byte("ok")
+	fileName := GetFileName(queueName, 2)
+	if err := os.MkdirAll(filepath.Dir(fileName), 0o755); err != nil {
+		t.Fatalf("failed to create queue dir: %v", err)
+	}
+	file, err := os.Create(fileName)
+	if err != nil {
+		t.Fatalf("failed to create segment file: %v", err)
+	}
+	if err := binary.Write(file, binary.BigEndian, int32(len(data))); err != nil {
+		t.Fatalf("failed to write message size: %v", err)
+	}
+	if _, err := file.Write(data); err != nil {
+		t.Fatalf("failed to write message body: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("failed to close segment file: %v", err)
+	}
+
+	dq := &DiskBasedQueue{
+		name:            queueName,
+		cfg:             &DiskQueueConfig{AutoSkipCorruptFile: true, MinMsgSize: 1, MaxMsgSize: 1024},
+		writeSegmentNum: 2,
+		writePos:        int64(4 + len(data)),
+	}
+	consumer := &Consumer{
+		ID:        "consumer-reset",
+		diskQueue: dq,
+		mCfg:      dq.cfg,
+		qCfg:      &corequeue.QueueConfig{Name: queueName},
+		cCfg:      &corequeue.ConsumerConfig{},
+		queue:     queueName,
+	}
+
+	if err := consumer.ResetOffset(1, 0); err != nil {
+		t.Fatalf("expected reset offset to skip to current write segment, got %v", err)
+	}
+	if consumer.segment != 2 {
+		t.Fatalf("expected consumer to move to segment 2, got %d", consumer.segment)
+	}
+	if consumer.reader == nil {
+		t.Fatalf("expected consumer reader to be initialized for segment 2")
+	}
+}
+
+func TestFetchMessagesRecoversToEmptyTailWithoutRescanningCorruptFile(t *testing.T) {
+	env1 := EmptyEnv()
+	env1.SystemConfig.PathConfig.Data = t.TempDir()
+	global.RegisterEnv(env1)
+
+	queueName := "fetch-empty-tail"
+	corruptFile := GetFileName(queueName, 1)
+	if err := os.MkdirAll(filepath.Dir(corruptFile), 0o755); err != nil {
+		t.Fatalf("failed to create queue dir: %v", err)
+	}
+	if err := os.WriteFile(corruptFile, []byte{0x7f, 0xff, 0xff, 0xff}, 0o644); err != nil {
+		t.Fatalf("failed to write corrupt segment: %v", err)
+	}
+
+	dq := &DiskBasedQueue{
+		name:            queueName,
+		cfg:             &DiskQueueConfig{AutoSkipCorruptFile: true, MinMsgSize: 1, MaxMsgSize: 1024},
+		writeSegmentNum: 3,
+		writePos:        0,
+	}
+	consumer := &Consumer{
+		ID:        "consumer-fetch",
+		diskQueue: dq,
+		mCfg:      dq.cfg,
+		qCfg:      &corequeue.QueueConfig{Name: queueName},
+		cCfg:      &corequeue.ConsumerConfig{},
+		queue:     queueName,
+	}
+
+	if err := consumer.ResetOffset(1, 0); err != nil {
+		t.Fatalf("failed to initialize consumer: %v", err)
+	}
+
+	ctx := &corequeue.Context{}
+	messages, timeout, err := consumer.FetchMessages(ctx, 1)
+	if err != nil {
+		t.Fatalf("expected corruption recovery without error, got %v", err)
+	}
+	if timeout {
+		t.Fatalf("did not expect timeout during corruption recovery")
+	}
+	if len(messages) != 0 {
+		t.Fatalf("expected no messages during recovery, got %d", len(messages))
+	}
+	if consumer.segment != dq.writeSegmentNum {
+		t.Fatalf("expected consumer to park on new tail segment %d, got %d", dq.writeSegmentNum, consumer.segment)
+	}
+	if ctx.NextOffset.Segment != dq.writeSegmentNum || ctx.NextOffset.Position != 0 {
+		t.Fatalf("expected next offset to advance to new tail, got %v", ctx.NextOffset)
+	}
+
+	payload := []byte("hello")
+	tailFile := GetFileName(queueName, dq.writeSegmentNum)
+	file, err := os.Create(tailFile)
+	if err != nil {
+		t.Fatalf("failed to create new tail segment: %v", err)
+	}
+	if err := binary.Write(file, binary.BigEndian, int32(len(payload))); err != nil {
+		t.Fatalf("failed to write tail message size: %v", err)
+	}
+	if _, err := file.Write(payload); err != nil {
+		t.Fatalf("failed to write tail message body: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("failed to close tail segment: %v", err)
+	}
+	dq.writePos = int64(4 + len(payload))
+
+	ctx = &corequeue.Context{}
+	messages, timeout, err = consumer.FetchMessages(ctx, 1)
+	if err != nil {
+		t.Fatalf("expected consumer to resume reading on new tail, got %v", err)
+	}
+	if timeout {
+		t.Fatalf("did not expect timeout when new tail data exists")
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected exactly one message, got %d", len(messages))
+	}
+	if string(messages[0].Data) != "hello" {
+		t.Fatalf("expected payload %q, got %q", "hello", string(messages[0].Data))
+	}
+}


### PR DESCRIPTION
## Summary
- park disk queue consumers on the current write tail after corruption-triggered segment skips instead of repeatedly rescanning missing files
- reopen the parked tail reader automatically once new data appears on the current write segment
- add focused disk queue recovery tests and release notes for the corruption-recovery path

## Testing
- go test ./modules/queue/disk_queue
