### PR TITLE
fix(metrics): respect collection mode for cluster and node tasks

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -25,6 +25,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add pluggable sink to host metrics collectors #288
 
 ### 🐛 Bug fix  
+- fix(metrics): respect collection mode for cluster and node/index metric tasks (test: `go test ./modules/metrics/...`) #323
 ### ✈️ Improvements  
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249

--- a/modules/metrics/elastic/elasticsearch.go
+++ b/modules/metrics/elastic/elasticsearch.go
@@ -127,6 +127,24 @@ func validateMonitorConfig(monitorConfig *elastic.TaskConfig) {
 	}
 }
 
+func (m *ElasticsearchMetric) shouldCollectMetrics(v *elastic.ElasticsearchMetadata) bool {
+	if v == nil || v.Config == nil {
+		return false
+	}
+	if !v.Config.Monitored || !v.Config.Enabled {
+		return false
+	}
+	if !m.IsAgentMode && v.Config.MetricCollectionMode == elastic.ModeAgent {
+		log.Debugf("cluster [%v] is in agent mode, skip console-side metric collection", v.Config.Name)
+		return false
+	}
+	if m.IsAgentMode && v.Config.MetricCollectionMode == elastic.ModeAgentless {
+		log.Debugf("cluster [%v] is in agentless mode, skip agent-side metric collection", v.Config.Name)
+		return false
+	}
+	return true
+}
+
 func (m *ElasticsearchMetric) Collect() error {
 	if !m.Enabled {
 		return nil
@@ -192,8 +210,8 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 			m.RemoveTask(taskID)
 		}
 	}
-	if !v.Config.Monitored || !v.Config.Enabled {
-		log.Debugf("cluster [%v] NOT (enabled[%v] or monitored[%v] or not available[%v]), skip collect", v.Config.Name, v.Config.Enabled, v.Config.Monitored, v.IsAvailable())
+	if !m.shouldCollectMetrics(v) {
+		log.Debugf("cluster [%v] NOT eligible for metrics collection (enabled[%v], monitored[%v], mode[%v], available[%v]), skip collect", v.Config.Name, v.Config.Enabled, v.Config.Monitored, v.Config.MetricCollectionMode, v.IsAvailable())
 		return true
 	}
 	if global.Env().IsDebug {

--- a/modules/metrics/elastic/elasticsearch.go
+++ b/modules/metrics/elastic/elasticsearch.go
@@ -134,12 +134,23 @@ func (m *ElasticsearchMetric) shouldCollectMetrics(v *elastic.ElasticsearchMetad
 	if !v.Config.Monitored || !v.Config.Enabled {
 		return false
 	}
-	if !m.IsAgentMode && v.Config.MetricCollectionMode == elastic.ModeAgent {
-		log.Debugf("cluster [%v] is in agent mode, skip console-side metric collection", v.Config.Name)
-		return false
-	}
 	if m.IsAgentMode && v.Config.MetricCollectionMode == elastic.ModeAgentless {
 		log.Debugf("cluster [%v] is in agentless mode, skip agent-side metric collection", v.Config.Name)
+		return false
+	}
+	return true
+}
+
+func (m *ElasticsearchMetric) shouldCollectClusterLevelMetrics(v *elastic.ElasticsearchMetadata) bool {
+	return m.shouldCollectMetrics(v)
+}
+
+func (m *ElasticsearchMetric) shouldCollectNodeAndIndexMetrics(v *elastic.ElasticsearchMetadata) bool {
+	if !m.shouldCollectMetrics(v) {
+		return false
+	}
+	if !m.IsAgentMode && v.Config.MetricCollectionMode == elastic.ModeAgent {
+		log.Debugf("cluster [%v] is in agent mode, skip console-side node/index metric collection", v.Config.Name)
 		return false
 	}
 	return true
@@ -220,7 +231,13 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 
 	var err error
 	monitorConfigs := getMonitorConfigs(v)
-	if m.ClusterHealth && monitorConfigs.ClusterHealth.Enabled {
+	clusterLevelEnabled := m.shouldCollectClusterLevelMetrics(v)
+	nodeAndIndexEnabled := m.shouldCollectNodeAndIndexMetrics(v)
+	if !clusterLevelEnabled && !nodeAndIndexEnabled {
+		log.Debugf("cluster [%v] has no eligible metric collectors (mode[%v], agent_mode[%v])", v.Config.Name, v.Config.MetricCollectionMode, m.IsAgentMode)
+		return true
+	}
+	if clusterLevelEnabled && m.ClusterHealth && monitorConfigs.ClusterHealth.Enabled {
 		log.Debugf("collect cluster health: %s, endpoint: %s", k, v.Config.GetAnyEndpoint())
 		var clusterHealthMetricTask = task.ScheduleTask{
 			ID:          clusterHealthTaskID,
@@ -244,7 +261,7 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 	}
 
 	//cluster stats
-	if m.ClusterStats && monitorConfigs.ClusterStats.Enabled {
+	if clusterLevelEnabled && m.ClusterStats && monitorConfigs.ClusterStats.Enabled {
 		log.Debugf("collect cluster state: %s, endpoint: %s", k, v.Config.GetAnyEndpoint())
 		var clusterStatsMetricTask = task.ScheduleTask{
 			ID:          clusterStatsTaskID,
@@ -268,7 +285,7 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 	}
 
 	//nodes stats
-	if m.NodeStats && monitorConfigs.NodeStats.Enabled {
+	if nodeAndIndexEnabled && m.NodeStats && monitorConfigs.NodeStats.Enabled {
 		var nodeStatsMetricTask = task.ScheduleTask{
 			ID:          nodeStatsTaskID,
 			Description: fmt.Sprintf("monitoring node stats metric for cluster %s", k),
@@ -344,7 +361,7 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 	}
 
 	//indices stats
-	if (m.AllIndexStats || m.IndexStats) && monitorConfigs.IndexStats.Enabled {
+	if nodeAndIndexEnabled && (m.AllIndexStats || m.IndexStats) && monitorConfigs.IndexStats.Enabled {
 		var indexStatsMetricTask = task.ScheduleTask{
 			ID:          indexStatsTaskID,
 			Description: fmt.Sprintf("monitoring index stats metric for cluster %s", k),

--- a/modules/metrics/elastic/elasticsearch_test.go
+++ b/modules/metrics/elastic/elasticsearch_test.go
@@ -6,7 +6,7 @@ import (
 	coreelastic "infini.sh/framework/core/elastic"
 )
 
-func TestShouldCollectMetricsSkipsConsoleCollectorInAgentMode(t *testing.T) {
+func TestShouldCollectMetricsAllowsConsoleCollectorInAgentModeForClusterLevelMetrics(t *testing.T) {
 	collector := &ElasticsearchMetric{}
 	meta := &coreelastic.ElasticsearchMetadata{
 		Config: &coreelastic.ElasticsearchConfig{
@@ -17,8 +17,11 @@ func TestShouldCollectMetricsSkipsConsoleCollectorInAgentMode(t *testing.T) {
 		},
 	}
 
-	if collector.shouldCollectMetrics(meta) {
-		t.Fatal("expected console-side collector to skip clusters in agent mode")
+	if !collector.shouldCollectMetrics(meta) {
+		t.Fatal("expected console-side collector to keep cluster-level metrics in agent mode")
+	}
+	if collector.shouldCollectNodeAndIndexMetrics(meta) {
+		t.Fatal("expected console-side collector to skip node/index metrics in agent mode")
 	}
 }
 
@@ -35,5 +38,40 @@ func TestShouldCollectMetricsAllowsConsoleCollectorInAgentlessMode(t *testing.T)
 
 	if !collector.shouldCollectMetrics(meta) {
 		t.Fatal("expected console-side collector to run for agentless clusters")
+	}
+	if !collector.shouldCollectNodeAndIndexMetrics(meta) {
+		t.Fatal("expected console-side collector to run node/index metrics for agentless clusters")
+	}
+}
+
+func TestShouldCollectMetricsSkipsAgentCollectorInAgentlessMode(t *testing.T) {
+	collector := &ElasticsearchMetric{IsAgentMode: true}
+	meta := &coreelastic.ElasticsearchMetadata{
+		Config: &coreelastic.ElasticsearchConfig{
+			Name:                 "agentless-cluster",
+			Enabled:              true,
+			Monitored:            true,
+			MetricCollectionMode: coreelastic.ModeAgentless,
+		},
+	}
+
+	if collector.shouldCollectMetrics(meta) {
+		t.Fatal("expected agent-side collector to skip agentless clusters")
+	}
+}
+
+func TestShouldCollectMetricsAllowsAgentCollectorInAgentMode(t *testing.T) {
+	collector := &ElasticsearchMetric{IsAgentMode: true}
+	meta := &coreelastic.ElasticsearchMetadata{
+		Config: &coreelastic.ElasticsearchConfig{
+			Name:                 "agent-cluster",
+			Enabled:              true,
+			Monitored:            true,
+			MetricCollectionMode: coreelastic.ModeAgent,
+		},
+	}
+
+	if !collector.shouldCollectMetrics(meta) {
+		t.Fatal("expected agent-side collector to run for agent mode clusters")
 	}
 }

--- a/modules/metrics/elastic/elasticsearch_test.go
+++ b/modules/metrics/elastic/elasticsearch_test.go
@@ -1,0 +1,39 @@
+package elastic
+
+import (
+	"testing"
+
+	coreelastic "infini.sh/framework/core/elastic"
+)
+
+func TestShouldCollectMetricsSkipsConsoleCollectorInAgentMode(t *testing.T) {
+	collector := &ElasticsearchMetric{}
+	meta := &coreelastic.ElasticsearchMetadata{
+		Config: &coreelastic.ElasticsearchConfig{
+			Name:                 "agent-cluster",
+			Enabled:              true,
+			Monitored:            true,
+			MetricCollectionMode: coreelastic.ModeAgent,
+		},
+	}
+
+	if collector.shouldCollectMetrics(meta) {
+		t.Fatal("expected console-side collector to skip clusters in agent mode")
+	}
+}
+
+func TestShouldCollectMetricsAllowsConsoleCollectorInAgentlessMode(t *testing.T) {
+	collector := &ElasticsearchMetric{}
+	meta := &coreelastic.ElasticsearchMetadata{
+		Config: &coreelastic.ElasticsearchConfig{
+			Name:                 "agentless-cluster",
+			Enabled:              true,
+			Monitored:            true,
+			MetricCollectionMode: coreelastic.ModeAgentless,
+		},
+	}
+
+	if !collector.shouldCollectMetrics(meta) {
+		t.Fatal("expected console-side collector to run for agentless clusters")
+	}
+}

--- a/modules/metrics/metrics.go
+++ b/modules/metrics/metrics.go
@@ -115,7 +115,8 @@ func (module *MetricsModule) Setup() {
 				// check other conditions
 				hasChanged = meta.IsAvailable() != oldMeta.IsAvailable() ||
 					meta.Config.Enabled != oldMeta.Config.Enabled ||
-					meta.Config.Monitored != oldMeta.Config.Monitored
+					meta.Config.Monitored != oldMeta.Config.Monitored ||
+					meta.Config.MetricCollectionMode != oldMeta.Config.MetricCollectionMode
 			}
 			if !hasChanged {
 				return


### PR DESCRIPTION
## Summary
- respect each cluster's metric collection mode when deciding whether console or agent should run metric tasks
- keep cluster-level metrics available in agent mode while skipping console-side node/index collectors there
- refresh metric tasks when the configured collection mode changes, with focused metrics tests and release notes

## Testing
- go test ./modules/metrics/...
