### PR TITLE
improve(pipeline): wait for loop release before deleting tasks

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- improve(pipeline): wait for loop release before deleting tasks (test: `go test ./modules/pipeline/...`) #326
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/modules/pipeline/pipeline.go
+++ b/modules/pipeline/pipeline.go
@@ -150,6 +150,11 @@ func (module *PipeModule) stopTask(taskID string) (exists bool) {
 
 // deleteTask will clean all in-memory states and release the pipeline context
 func (module *PipeModule) deleteTask(taskID string) {
+	if ctx, ok := module.contexts.Load(taskID); ok {
+		if v1, ok := ctx.(*pipeline.Context); ok && !v1.IsLoopReleased() {
+			module.stopAndWaitForRelease([]string{taskID}, time.Minute)
+		}
+	}
 	module.pipelines.Delete(taskID)
 	module.configs.Delete(taskID)
 	module.releaseContext(taskID)

--- a/modules/pipeline/pipeline_test.go
+++ b/modules/pipeline/pipeline_test.go
@@ -1,0 +1,50 @@
+package pipeline
+
+import (
+	"testing"
+	"time"
+
+	corepipeline "infini.sh/framework/core/pipeline"
+)
+
+func TestDeleteTaskWaitsForLoopRelease(t *testing.T) {
+	module := &PipeModule{}
+	ctx := corepipeline.AcquireContext(corepipeline.PipelineConfigV2{})
+
+	module.contexts.Store("task-1", ctx)
+	module.configs.Store("task-1", corepipeline.PipelineConfigV2{Name: "task-1"})
+	module.pipelines.Store("task-1", struct{}{})
+
+	released := make(chan struct{})
+	go func() {
+		for !ctx.IsCanceled() {
+			time.Sleep(time.Millisecond)
+		}
+		time.Sleep(50 * time.Millisecond)
+		ctx.SetLoopReleased()
+		close(released)
+	}()
+
+	start := time.Now()
+	module.deleteTask("task-1")
+	elapsed := time.Since(start)
+
+	select {
+	case <-released:
+	default:
+		t.Fatal("expected deleteTask to wait for loop release")
+	}
+
+	if elapsed < 50*time.Millisecond {
+		t.Fatalf("expected deleteTask to wait for loop release, returned after %v", elapsed)
+	}
+	if _, ok := module.contexts.Load("task-1"); ok {
+		t.Fatal("expected context to be deleted")
+	}
+	if _, ok := module.configs.Load("task-1"); ok {
+		t.Fatal("expected config to be deleted")
+	}
+	if _, ok := module.pipelines.Load("task-1"); ok {
+		t.Fatal("expected pipeline to be deleted")
+	}
+}


### PR DESCRIPTION
## Summary
- wait for active pipeline loops to finish releasing before deleteTask clears in-memory state
- cover the loop-release wait path with a focused pipeline module test
- add release notes for the safer pipeline task deletion behavior

## Testing
- go test ./modules/pipeline/...
