### PR TITLE
improve(elastic): treat empty strings as missing in partition filters

### DIFF
--- a/core/elastic/partition.go
+++ b/core/elastic/partition.go
@@ -754,7 +754,7 @@ func buildHashPartitionFilter(partitionID, partitionCount int, fieldName string,
 			"script": util.MapStr{
 				"script": util.MapStr{
 					"lang":   "painless",
-					"source": fmt.Sprintf("doc[%s].size()!=0 && (((doc[%s].value.hashCode() %% params.partition_count) + params.partition_count) %% params.partition_count) == params.partition_id", fieldLiteral, fieldLiteral),
+					"source": fmt.Sprintf("doc[%s].size()!=0 && doc[%s].value != '' && (((doc[%s].value.hashCode() %% params.partition_count) + params.partition_count) %% params.partition_count) == params.partition_id", fieldLiteral, fieldLiteral, fieldLiteral),
 					"params": util.MapStr{
 						"partition_count": partitionCount,
 						"partition_id":    partitionID,
@@ -833,34 +833,35 @@ func getErrorDetailMessage(err *ErrorDetail) string {
 func buildMissingFieldCondition(fieldName string) util.MapStr {
 	return util.MapStr{
 		"bool": util.MapStr{
-			"must_not": []interface{}{
+			"should": []interface{}{
 				util.MapStr{
-					"exists": util.MapStr{
-						"field": fieldName,
+					"bool": util.MapStr{
+						"must_not": []interface{}{
+							util.MapStr{
+								"exists": util.MapStr{
+									"field": fieldName,
+								},
+							},
+						},
+					},
+				},
+				util.MapStr{
+					"term": util.MapStr{
+						fieldName: util.MapStr{
+							"value": "",
+						},
 					},
 				},
 			},
+			"minimum_should_match": 1,
 		},
 	}
 }
 
 func buildMissingFieldFilter(fieldName string, filter interface{}) util.MapStr {
-	boolFilter := util.MapStr{
-		"must": []interface{}{},
-		"must_not": []interface{}{
-			util.MapStr{
-				"exists": util.MapStr{
-					"field": fieldName,
-				},
-			},
-		},
-	}
-	if filter != nil {
-		boolFilter["must"] = append(boolFilter["must"].([]interface{}), filter)
-	}
-	return util.MapStr{
-		"bool": boolFilter,
-	}
+	return buildMustPartitionFilter([]interface{}{
+		buildMissingFieldCondition(fieldName),
+	}, filter)
 }
 
 func buildMustPartitionFilter(mustClauses []interface{}, filter interface{}) util.MapStr {

--- a/core/elastic/partition_test.go
+++ b/core/elastic/partition_test.go
@@ -1,0 +1,213 @@
+package elastic
+
+import (
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"infini.sh/framework/core/util"
+)
+
+func TestBuildQuantilePercents(t *testing.T) {
+	got := buildQuantilePercents(4)
+	want := []float64{25, 50, 75}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected percents: got %v want %v", got, want)
+	}
+}
+
+func TestBuildQuantilePartitionsCreatesOpenEdgeRanges(t *testing.T) {
+	partitions := buildQuantilePartitions([]float64{10, 20, 30}, "value", PartitionByNumber, nil)
+	if len(partitions) != 2 {
+		t.Fatalf("unexpected partition count: %d", len(partitions))
+	}
+
+	firstRange := getMustClause(t, partitions[0].Filter)["range"].(util.MapStr)["value"].(util.MapStr)
+	if _, ok := firstRange["gt"]; ok {
+		t.Fatalf("expected first partition to have no lower bound, got %v", firstRange)
+	}
+	if got := firstRange["lte"]; got != float64(20) {
+		t.Fatalf("unexpected first upper bound: %v", got)
+	}
+
+	secondRange := getMustClause(t, partitions[1].Filter)["range"].(util.MapStr)["value"].(util.MapStr)
+	if got := secondRange["gt"]; got != float64(20) {
+		t.Fatalf("unexpected second lower bound: %v", got)
+	}
+	if _, ok := secondRange["lte"]; ok {
+		t.Fatalf("expected last partition to have no upper bound, got %v", secondRange)
+	}
+}
+
+func TestBuildQuantilePartitionsSinglePartitionUsesExistsFilter(t *testing.T) {
+	partitions := buildQuantilePartitions([]float64{5, 5}, "value", PartitionByNumber, nil)
+	if len(partitions) != 1 {
+		t.Fatalf("unexpected partition count: %d", len(partitions))
+	}
+
+	clause := getMustClause(t, partitions[0].Filter)
+	exists, ok := clause["exists"].(util.MapStr)
+	if !ok {
+		t.Fatalf("expected exists clause, got %v", clause)
+	}
+	if exists["field"] != "value" {
+		t.Fatalf("unexpected exists field: %v", exists["field"])
+	}
+}
+
+func TestBuildOpenPartitionFilterPreservesDateFormat(t *testing.T) {
+	upper := 1000.0
+	filter := buildOpenPartitionFilter(nil, &upper, "ts", PartitionByDate, nil)
+	rangeFilter := getMustClause(t, filter)["range"].(util.MapStr)["ts"].(util.MapStr)
+	if got := rangeFilter["format"]; got != "epoch_millis" {
+		t.Fatalf("unexpected date format: %v", got)
+	}
+}
+
+func TestBuildExactTermPartitionFilter(t *testing.T) {
+	filter := buildExactTermPartitionFilter("pmid-1", "pmid.keyword", nil)
+	termFilter := getMustClause(t, filter)["term"].(util.MapStr)["pmid.keyword"].(util.MapStr)
+	if got := termFilter["value"]; got != "pmid-1" {
+		t.Fatalf("unexpected term value: %v", got)
+	}
+}
+
+func TestBuildOtherTermsPartitionFilter(t *testing.T) {
+	filter := buildOtherTermsPartitionFilter([]string{"a", "b"}, "pmid.keyword", nil)
+	boolFilter := filter["bool"].(util.MapStr)
+	mustNot := boolFilter["must_not"].([]interface{})
+	termsFilter := mustNot[0].(util.MapStr)["terms"].(util.MapStr)
+	values := termsFilter["pmid.keyword"].([]string)
+	if !reflect.DeepEqual(values, []string{"a", "b"}) {
+		t.Fatalf("unexpected excluded values: %v", values)
+	}
+}
+
+func TestBuildHashPartitionFilter(t *testing.T) {
+	filter := buildHashPartitionFilter(1, 8, "pmid.keyword", nil)
+	scriptFilter := getMustClause(t, filter)["script"].(util.MapStr)["script"].(util.MapStr)
+	if scriptFilter["lang"] != "painless" {
+		t.Fatalf("unexpected script language: %v", scriptFilter["lang"])
+	}
+	source, ok := scriptFilter["source"].(string)
+	if !ok {
+		t.Fatalf("unexpected script source: %T", scriptFilter["source"])
+	}
+	if !strings.Contains(source, "doc['pmid.keyword']") {
+		t.Fatalf("unexpected script source: %s", source)
+	}
+	if !strings.Contains(source, "value != ''") {
+		t.Fatalf("expected empty strings to be excluded from hash partition, got %s", source)
+	}
+	if strings.Contains(source, "Math.floorMod") {
+		t.Fatalf("unexpected script source: %s", source)
+	}
+	params := scriptFilter["params"].(util.MapStr)
+	if params["partition_count"] != 8 || params["partition_id"] != 1 {
+		t.Fatalf("unexpected script params: %v", params)
+	}
+	if _, ok := params["field"]; ok {
+		t.Fatalf("field should not be passed as a script param: %v", params)
+	}
+}
+
+func TestBuildMissingFieldConditionIncludesEmptyString(t *testing.T) {
+	filter := buildMissingFieldCondition("pmid.keyword")
+	boolFilter, ok := filter["bool"].(util.MapStr)
+	if !ok {
+		t.Fatalf("expected bool filter, got %v", filter)
+	}
+	if got := boolFilter["minimum_should_match"]; got != 1 {
+		t.Fatalf("unexpected minimum_should_match: %v", got)
+	}
+	should, ok := boolFilter["should"].([]interface{})
+	if !ok || len(should) != 2 {
+		t.Fatalf("expected two should clauses, got %v", boolFilter["should"])
+	}
+	termFilter := should[1].(util.MapStr)["term"].(util.MapStr)["pmid.keyword"].(util.MapStr)
+	if got := termFilter["value"]; got != "" {
+		t.Fatalf("unexpected empty-string term filter: %v", termFilter)
+	}
+}
+
+func TestBuildMissingFieldFilterPreservesOuterFilter(t *testing.T) {
+	filter := buildMissingFieldFilter("pmid.keyword", util.MapStr{
+		"term": util.MapStr{
+			"env": util.MapStr{"value": "prod"},
+		},
+	})
+	boolFilter, ok := filter["bool"].(util.MapStr)
+	if !ok {
+		t.Fatalf("expected bool filter, got %v", filter)
+	}
+	must, ok := boolFilter["must"].([]interface{})
+	if !ok || len(must) != 2 {
+		t.Fatalf("expected two must clauses, got %v", boolFilter["must"])
+	}
+	innerBool, ok := must[0].(util.MapStr)["bool"].(util.MapStr)
+	if !ok {
+		t.Fatalf("expected wrapped missing bool filter, got %v", must[0])
+	}
+	if got := innerBool["minimum_should_match"]; got != 1 {
+		t.Fatalf("unexpected minimum_should_match: %v", got)
+	}
+}
+
+func TestBuildPainlessStringLiteralEscapesSingleQuote(t *testing.T) {
+	got := buildPainlessStringLiteral("foo'bar")
+	if got != `'foo\'bar'` {
+		t.Fatalf("unexpected painless string literal: %s", got)
+	}
+}
+
+func TestEnsurePartitionSearchResponseOKReturnsBackendReason(t *testing.T) {
+	err := ensurePartitionSearchResponseOK(&SearchResponse{
+		ResponseBase: ResponseBase{
+			StatusCode: http.StatusInternalServerError,
+			RawResult: &util.Result{
+				Body: []byte(`{"error":{"reason":"runtime script failure"},"status":500}`),
+			},
+			InternalError: InternalError{
+				Error: &ErrorDetail{
+					Reason: "runtime script failure",
+				},
+				Status: http.StatusInternalServerError,
+			},
+		},
+	})
+	if err == nil || err.Error() != "runtime script failure" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsurePartitionSearchResponseOKReturnsCausedByReason(t *testing.T) {
+	err := ensurePartitionSearchResponseOK(&SearchResponse{
+		ResponseBase: ResponseBase{
+			StatusCode: http.StatusBadRequest,
+			RawResult: &util.Result{
+				Body: []byte(`{"error":{"root_cause":[{"reason":"compile error"}],"failed_shards":[{"reason":{"reason":"compile error","caused_by":{"reason":"static method [java.lang.Math, floorMod/2] not found"}}}],"reason":"all shards failed"},"status":400}`),
+			},
+		},
+	})
+	if err == nil || err.Error() != "static method [java.lang.Math, floorMod/2] not found" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func getMustClause(t *testing.T, filter util.MapStr) util.MapStr {
+	t.Helper()
+	boolFilter, ok := filter["bool"].(util.MapStr)
+	if !ok {
+		t.Fatalf("expected bool filter, got %v", filter)
+	}
+	must, ok := boolFilter["must"].([]interface{})
+	if !ok || len(must) == 0 {
+		t.Fatalf("expected must clauses, got %v", boolFilter["must"])
+	}
+	clause, ok := must[0].(util.MapStr)
+	if !ok {
+		t.Fatalf("expected util.MapStr clause, got %T", must[0])
+	}
+	return clause
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -27,6 +27,7 @@ Information about release notes of INFINI Framework is provided here.
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 - improve(elastic): add hash and terms partition strategies (test: `go test ./core/elastic`) #327
+- improve(elastic): treat empty strings as missing in partition filters (test: `go test ./core/elastic`) #328
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- exclude empty-string keyword values from hash partition scripts
- treat empty strings as missing values when building missing-value partition filters
- add focused core elastic tests and release notes for the missing-value partition behavior

## Testing
- go test ./core/elastic

## Stack
- depends on #327
