### PR TITLE
fix(elastic): round date percentile partition boundaries

### DIFF
--- a/core/elastic/partition.go
+++ b/core/elastic/partition.go
@@ -652,6 +652,8 @@ func buildBoundedPartitionFilter(min, max float64, fieldName, fieldType string, 
 		"lte": max,
 	}
 	if fieldType == PartitionByDate {
+		rv["gte"] = normalizeDateRangeBoundary(min, true, true)
+		rv["lte"] = normalizeDateRangeBoundary(max, false, true)
 		rv["format"] = "epoch_millis"
 	}
 	must := []interface{}{
@@ -680,6 +682,12 @@ func buildOpenPartitionFilter(lower, upper *float64, fieldName, fieldType string
 		rv["lte"] = *upper
 	}
 	if fieldType == PartitionByDate {
+		if lower != nil {
+			rv["gt"] = normalizeDateRangeBoundary(*lower, true, false)
+		}
+		if upper != nil {
+			rv["lte"] = normalizeDateRangeBoundary(*upper, false, true)
+		}
 		rv["format"] = "epoch_millis"
 	}
 	var condition interface{}
@@ -706,6 +714,19 @@ func buildOpenPartitionFilter(lower, upper *float64, fieldName, fieldType string
 		},
 	}
 
+}
+
+func normalizeDateRangeBoundary(value float64, lower, inclusive bool) int64 {
+	switch {
+	case lower && inclusive:
+		return int64(math.Ceil(value))
+	case lower && !inclusive:
+		return int64(math.Floor(value))
+	case !lower && inclusive:
+		return int64(math.Floor(value))
+	default:
+		return int64(math.Ceil(value))
+	}
 }
 
 func buildExactTermPartitionFilter(value, fieldName string, filter interface{}) util.MapStr {

--- a/core/elastic/partition_test.go
+++ b/core/elastic/partition_test.go
@@ -63,6 +63,33 @@ func TestBuildOpenPartitionFilterPreservesDateFormat(t *testing.T) {
 	if got := rangeFilter["format"]; got != "epoch_millis" {
 		t.Fatalf("unexpected date format: %v", got)
 	}
+	if got := rangeFilter["lte"]; got != int64(1000) {
+		t.Fatalf("unexpected upper bound: %v", got)
+	}
+}
+
+func TestBuildOpenPartitionFilterRoundsDatePercentileBoundaries(t *testing.T) {
+	lower := 1779109187904.8455
+	upper := 1779109187999.999
+	filter := buildOpenPartitionFilter(&lower, &upper, "created_at", PartitionByDate, nil)
+	rangeFilter := getMustClause(t, filter)["range"].(util.MapStr)["created_at"].(util.MapStr)
+	if got := rangeFilter["gt"]; got != int64(1779109187904) {
+		t.Fatalf("unexpected lower bound: %v", got)
+	}
+	if got := rangeFilter["lte"]; got != int64(1779109187999) {
+		t.Fatalf("unexpected upper bound: %v", got)
+	}
+}
+
+func TestBuildBoundedPartitionFilterRoundsDateBoundaries(t *testing.T) {
+	filter := buildBoundedPartitionFilter(1779109187904.1, 1779109187999.9, "created_at", PartitionByDate, nil)
+	rangeFilter := getMustClause(t, filter)["range"].(util.MapStr)["created_at"].(util.MapStr)
+	if got := rangeFilter["gte"]; got != int64(1779109187905) {
+		t.Fatalf("unexpected lower bound: %v", got)
+	}
+	if got := rangeFilter["lte"]; got != int64(1779109187999) {
+		t.Fatalf("unexpected upper bound: %v", got)
+	}
 }
 
 func TestBuildExactTermPartitionFilter(t *testing.T) {

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -25,6 +25,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add pluggable sink to host metrics collectors #288
 
 ### 🐛 Bug fix  
+- fix(elastic): round date percentile boundaries for partition filters (test: `go test ./core/elastic`) #329
 ### ✈️ Improvements  
 - improve(elastic): add hash and terms partition strategies (test: `go test ./core/elastic`) #327
 - improve(elastic): treat empty strings as missing in partition filters (test: `go test ./core/elastic`) #328


### PR DESCRIPTION
## Summary
- normalize fractional date percentile boundaries before building bounded/open partition range filters
- keep generated date ranges aligned to valid epoch_millis values for both open and closed bounds
- add focused core elastic tests and release notes for the date-boundary rounding behavior

## Testing
- go test ./core/elastic

## Stack
- depends on #328
