### PR TITLE
improve(elastic): prefer available seed hosts

### DIFF
--- a/core/elastic/actions.go
+++ b/core/elastic/actions.go
@@ -186,13 +186,8 @@ func (meta *ElasticsearchMetadata) GetActiveEndpoint() string {
 }
 
 func (meta *ElasticsearchMetadata) GetActivePreferredSeedHost() string {
-	hosts := meta.GetSeedHosts()
-	if len(hosts) > 0 {
-		for _, v := range hosts {
-			if v != "" && IsHostAvailable(v) {
-				return v
-			}
-		}
+	if host, _ := meta.getAvailableSeedHost(); host != "" {
+		return host
 	}
 	return meta.Config.Host
 }
@@ -263,6 +258,12 @@ func (meta *ElasticsearchMetadata) GetActiveHosts() int {
 }
 
 func (meta *ElasticsearchMetadata) GetActiveHost() string {
+	if host, info := meta.getAvailableSeedHost(); host != "" {
+		if info != nil {
+			meta.activeHost = info
+		}
+		return host
+	}
 
 	if meta.activeHost != nil {
 		if meta.activeHost.IsAvailable() {
@@ -318,6 +319,25 @@ func (meta *ElasticsearchMetadata) GetActiveHost() string {
 	}
 	meta.ReportFailure(nil)
 	return hosts[0]
+}
+
+func (meta *ElasticsearchMetadata) getAvailableSeedHost() (string, *NodeAvailable) {
+	hosts := meta.GetSeedHosts()
+	if hosts == nil || len(hosts) == 0 {
+		return "", nil
+	}
+
+	for _, host := range hosts {
+		if host == "" || !IsHostAvailable(host) {
+			continue
+		}
+		if info, ok := GetHostAvailableInfo(host); ok && info != nil && info.IsAvailable() {
+			return host, info
+		}
+		return host, nil
+	}
+
+	return "", nil
 }
 
 func (meta *ElasticsearchMetadata) IsTLS() bool {

--- a/core/elastic/actions_test.go
+++ b/core/elastic/actions_test.go
@@ -1,0 +1,90 @@
+package elastic
+
+import (
+	"testing"
+	"time"
+
+	"infini.sh/framework/core/orm"
+)
+
+func TestGetActiveHostPrefersAvailableSeedHostOverCachedDiscoveredHost(t *testing.T) {
+	const (
+		clusterID      = "docker-mapped-port-cluster"
+		seedHost       = "192.168.3.185:9211"
+		discoveredHost = "172.18.1.18:9200"
+	)
+
+	cfg := &ElasticsearchConfig{
+		ORMObjectBase: orm.ORMObjectBase{ID: clusterID},
+		Name:          clusterID,
+		Host:          seedHost,
+		Hosts:         []string{seedHost},
+		Enabled:       true,
+	}
+	cfg.Discovery.Enabled = true
+
+	meta := &ElasticsearchMetadata{
+		Config: cfg,
+		Nodes: &map[string]NodesInfo{
+			"node-1": {
+				Http: struct {
+					BoundAddress            []string `json:"bound_address"`
+					PublishAddress          string   `json:"publish_address,omitempty"`
+					MaxContentLengthInBytes int64    `json:"max_content_length_in_bytes,omitempty"`
+				}{
+					PublishAddress: discoveredHost,
+				},
+			},
+		},
+		activeHost: &NodeAvailable{Host: discoveredHost, available: true, lastCheck: time.Now()},
+	}
+
+	hosts.Store(seedHost, &NodeAvailable{Host: seedHost, ClusterID: clusterID, available: true, lastCheck: time.Now()})
+	hosts.Store(discoveredHost, &NodeAvailable{Host: discoveredHost, ClusterID: clusterID, available: true, lastCheck: time.Now()})
+	t.Cleanup(func() {
+		hosts.Delete(seedHost)
+		hosts.Delete(discoveredHost)
+	})
+
+	got := meta.GetActiveHost()
+	if got != seedHost {
+		t.Fatalf("expected seed host %q to be preferred over discovered host %q, got %q", seedHost, discoveredHost, got)
+	}
+	if meta.activeHost == nil || meta.activeHost.Host != seedHost {
+		t.Fatalf("expected activeHost to be updated to seed host %q, got %#v", seedHost, meta.activeHost)
+	}
+}
+
+func TestGetActiveHostFallsBackToCachedDiscoveredHostWhenSeedUnavailable(t *testing.T) {
+	const (
+		clusterID      = "docker-discovery-fallback-cluster"
+		seedHost       = "192.168.3.185:9211"
+		discoveredHost = "172.18.1.18:9200"
+	)
+
+	cfg := &ElasticsearchConfig{
+		ORMObjectBase: orm.ORMObjectBase{ID: clusterID},
+		Name:          clusterID,
+		Host:          seedHost,
+		Hosts:         []string{seedHost},
+		Enabled:       true,
+	}
+	cfg.Discovery.Enabled = true
+
+	meta := &ElasticsearchMetadata{
+		Config:     cfg,
+		activeHost: &NodeAvailable{Host: discoveredHost, available: true, lastCheck: time.Now()},
+	}
+
+	hosts.Store(seedHost, &NodeAvailable{Host: seedHost, ClusterID: clusterID, available: false, lastCheck: time.Now()})
+	hosts.Store(discoveredHost, &NodeAvailable{Host: discoveredHost, ClusterID: clusterID, available: true, lastCheck: time.Now()})
+	t.Cleanup(func() {
+		hosts.Delete(seedHost)
+		hosts.Delete(discoveredHost)
+	})
+
+	got := meta.GetActiveHost()
+	if got != discoveredHost {
+		t.Fatalf("expected discovered host %q when seed host is unavailable, got %q", discoveredHost, got)
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- improve(elastic): prefer available seed hosts for active cluster selection (test: `go test ./core/elastic ./modules/elastic/common`) #331
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/modules/elastic/common/config.go
+++ b/modules/elastic/common/config.go
@@ -219,6 +219,9 @@ func InitElasticInstance(esConfig elastic.ElasticsearchConfig) (elastic.API, err
 		log.Warn("elasticsearch ", esConfig.Name, " is not enabled")
 		return nil, nil
 	}
+	originMeta := elastic.GetMetadata(esConfig.ID)
+	initHealth := getInitialMetadataHealth(originMeta)
+
 	client, err := InitClientWithConfig(esConfig)
 	if err != nil {
 		log.Error("elasticsearch ", esConfig.Name, err)
@@ -226,18 +229,19 @@ func InitElasticInstance(esConfig elastic.ElasticsearchConfig) (elastic.API, err
 	}
 	elastic.RegisterInstance(esConfig, client)
 
-	originMeta := elastic.GetMetadata(esConfig.ID)
-	initHealth := true
-	if originMeta != nil {
-		initHealth = originMeta.IsAvailable()
-	}
-
 	v := elastic.InitMetadata(&esConfig, initHealth)
 	if v.Health == nil && originMeta != nil {
 		v.Health = originMeta.Health
 	}
 	elastic.SetMetadata(esConfig.ID, v)
 	return client, err
+}
+
+func getInitialMetadataHealth(originMeta *elastic.ElasticsearchMetadata) bool {
+	if originMeta == nil {
+		return true
+	}
+	return originMeta.IsAvailable()
 }
 
 func GetBasicAuth(esConfig *elastic.ElasticsearchConfig) (basicAuth *model.BasicAuth, err error) {

--- a/modules/elastic/common/config_test.go
+++ b/modules/elastic/common/config_test.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"testing"
+
+	"infini.sh/framework/core/elastic"
+)
+
+func TestGetInitialMetadataHealthDefaultsToAvailableForNewCluster(t *testing.T) {
+	if !getInitialMetadataHealth(nil) {
+		t.Fatal("expected new cluster metadata to start as available before first health check")
+	}
+}
+
+func TestGetInitialMetadataHealthKeepsExistingAvailability(t *testing.T) {
+	meta := &elastic.ElasticsearchMetadata{Config: &elastic.ElasticsearchConfig{Enabled: true}}
+	meta.Init(false)
+
+	if getInitialMetadataHealth(meta) {
+		t.Fatal("expected existing unavailable metadata to remain unavailable")
+	}
+
+	meta.Init(true)
+	if !getInitialMetadataHealth(meta) {
+		t.Fatal("expected existing available metadata to remain available")
+	}
+}


### PR DESCRIPTION
## Summary
- prefer healthy seed hosts over cached discovered hosts when choosing the active elastic endpoint
- preserve existing cluster availability on re-init while keeping new clusters healthy by default
- add focused elastic tests and release notes for the seed-host selection behavior

## Testing
- go test ./core/elastic ./modules/elastic/common
