### PR TITLE
fix(config): preserve section reload callback order

### DIFF
--- a/core/config/fs_watcher.go
+++ b/core/config/fs_watcher.go
@@ -62,6 +62,35 @@ func loadConfigFile(file string) *Config {
 	return nil
 }
 
+func dispatchConfigChangeEvent(ev fsnotify.Event, watcherCallbacks []CallbackFunc) {
+	for _, v := range watcherCallbacks {
+		v(ev.Name, ev.Op)
+	}
+
+	cfg := loadConfigFile(ev.Name)
+	if cfg != nil {
+		for _, k := range sectionCallbackOrder {
+			callbacks, ok := sectionCallbacks[k]
+			if !ok || !cfg.HasField(k) {
+				continue
+			}
+			currentCfg, err := cfg.Child(k, -1)
+			if err != nil {
+				log.Error(err)
+				continue
+			}
+			previousCfg, _ := latestConfig[k]
+			for _, f := range callbacks {
+				f(previousCfg, currentCfg)
+			}
+			latestConfig[k] = currentCfg
+		}
+	}
+
+	for _, v := range configCallbacks {
+		v(ev)
+	}
+}
 var validExtensions = []string{".yml", ".yaml", ".tpl"}
 
 func SetValidExtension(v []string) {
@@ -153,40 +182,7 @@ func AddPathToWatch(path string, callback CallbackFunc) {
 				time.Sleep(2 * time.Second)
 				log.Trace("2 seconds out, on:", ev.String())
 
-				// AddPathToWatch
-
-				for _, v := range watcher.callbacks {
-					v(ev.Name, ev.Op)
-				}
-
-				// NotifyOnConfigChange
-
-				for _, v := range configCallbacks {
-					v(ev)
-				}
-
-				// NotifyOnConfigSectionChange
-
-				cfg := loadConfigFile(ev.Name)
-				if cfg == nil {
-					continue
-				}
-
-				for k, v := range sectionCallbacks {
-					if cfg.HasField(k) {
-						currentCfg, err := cfg.Child(k, -1)
-						if err != nil {
-							log.Error(err)
-							continue
-						}
-						// diff config
-						previousCfg, _ := latestConfig[k]
-						for _, f := range v {
-							f(previousCfg, currentCfg)
-						}
-						latestConfig[k] = currentCfg
-					}
-				}
+				dispatchConfigChangeEvent(ev, watcher.callbacks)
 			}
 		}()
 	})
@@ -255,6 +251,7 @@ func StopWatchers() {
 }
 
 var sectionCallbacks = map[string][]func(pCfg, cCfg *Config){}
+var sectionCallbackOrder = []string{}
 var configCallbacks = []func(fsnotify.Event){}
 var cfgLocker = sync.RWMutex{}
 
@@ -268,6 +265,7 @@ func NotifyOnConfigSectionChange(configKey string, f func(pCfg, cCfg *Config)) {
 	if !ok {
 		v = []func(pCfg, cCfg *Config){}
 		sectionCallbacks[configKey] = v
+		sectionCallbackOrder = append(sectionCallbackOrder, configKey)
 	}
 	v = append(v, f)
 	sectionCallbacks[configKey] = v

--- a/core/config/fs_watcher_test.go
+++ b/core/config/fs_watcher_test.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+func TestDispatchConfigChangeEventRunsSectionCallbacksBeforeGenericCallbacks(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "generated_metrics_tasks.yml")
+	content := []byte("elasticsearch:\n  - id: \"cluster-1\"\n    name: \"cluster-1\"\n    enabled: true\n    endpoint: \"http://127.0.0.1:9200\"\n")
+	if err := os.WriteFile(file, content, 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	previousSections := sectionCallbacks
+	previousOrder := sectionCallbackOrder
+	previousConfigs := configCallbacks
+	previousLatest := latestConfig
+	sectionCallbacks = map[string][]func(pCfg, cCfg *Config){}
+	sectionCallbackOrder = nil
+	configCallbacks = nil
+	latestConfig = map[string]*Config{}
+	t.Cleanup(func() {
+		sectionCallbacks = previousSections
+		sectionCallbackOrder = previousOrder
+		configCallbacks = previousConfigs
+		latestConfig = previousLatest
+	})
+
+	var order []string
+	NotifyOnConfigSectionChange("elasticsearch", func(pCfg, cCfg *Config) {
+		order = append(order, "section")
+	})
+	NotifyOnConfigChange(func(ev fsnotify.Event) {
+		order = append(order, "generic")
+	})
+
+	dispatchConfigChangeEvent(fsnotify.Event{Name: file, Op: fsnotify.Write}, nil)
+
+	if len(order) != 2 {
+		t.Fatalf("expected 2 callbacks, got %d (%v)", len(order), order)
+	}
+	if order[0] != "section" || order[1] != "generic" {
+		t.Fatalf("expected section callback before generic callback, got %v", order)
+	}
+}
+
+func TestDispatchConfigChangeEventRunsSectionCallbacksInRegistrationOrder(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "gateway.yml")
+	content := []byte("flow:\n  - name: flow-1\nrouter:\n  - name: router-1\nentry:\n  - name: entry-1\n")
+	if err := os.WriteFile(file, content, 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
+
+	previousSections := sectionCallbacks
+	previousOrder := sectionCallbackOrder
+	previousConfigs := configCallbacks
+	previousLatest := latestConfig
+	sectionCallbacks = map[string][]func(pCfg, cCfg *Config){}
+	sectionCallbackOrder = nil
+	configCallbacks = nil
+	latestConfig = map[string]*Config{}
+	t.Cleanup(func() {
+		sectionCallbacks = previousSections
+		sectionCallbackOrder = previousOrder
+		configCallbacks = previousConfigs
+		latestConfig = previousLatest
+	})
+
+	var order []string
+	NotifyOnConfigSectionChange("flow", func(pCfg, cCfg *Config) {
+		order = append(order, "flow")
+	})
+	NotifyOnConfigSectionChange("router", func(pCfg, cCfg *Config) {
+		order = append(order, "router")
+	})
+	NotifyOnConfigSectionChange("entry", func(pCfg, cCfg *Config) {
+		order = append(order, "entry")
+	})
+
+	dispatchConfigChangeEvent(fsnotify.Event{Name: file, Op: fsnotify.Write}, nil)
+
+	expected := []string{"flow", "router", "entry"}
+	if len(order) != len(expected) {
+		t.Fatalf("expected %d callbacks, got %d (%v)", len(expected), len(order), order)
+	}
+	for i, want := range expected {
+		if order[i] != want {
+			t.Fatalf("expected callback order %v, got %v", expected, order)
+		}
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -25,6 +25,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add pluggable sink to host metrics collectors #288
 
 ### 🐛 Bug fix  
+- fix(config): preserve section reload callback order during watcher dispatch (test: `go test ./core/config/...`) #332
 ### ✈️ Improvements  
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249


### PR DESCRIPTION
## Summary
- preserve config section callback registration order during reload dispatch
- route the watcher event loop through the shared dispatch helper so runtime behavior matches tests
- add focused config tests and release notes for the reload callback ordering fix

## Testing
- go test ./core/config/...
