### PR TITLE
fix(elastic): probe version without unavailable runtime metadata

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -25,6 +25,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add pluggable sink to host metrics collectors #288
 
 ### 🐛 Bug fix  
+- fix(elastic): probe cluster version without reusing unavailable runtime metadata (test: `go test ./modules/elastic/common`) #333
 ### ✈️ Improvements  
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249

--- a/modules/elastic/common/config.go
+++ b/modules/elastic/common/config.go
@@ -87,7 +87,9 @@ func InitClientWithConfig(esConfig elastic.ElasticsearchConfig) (client elastic.
 		ver string
 	)
 	if esConfig.Version == "" || esConfig.Version == "auto" {
-		verInfo, err := adapter.ClusterVersion(elastic.GetOrInitMetadata(&esConfig))
+		probeMeta := &elastic.ElasticsearchMetadata{Config: &esConfig}
+		probeMeta.Init(true)
+		verInfo, err := adapter.ClusterVersion(probeMeta)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Summary
- probe elastic cluster version with fresh metadata instead of reusing runtime availability state
- avoid version detection failures when the cached active host is unavailable but the configured endpoint is still probeable
- add release notes for the version probe fix

## Testing
- go test ./modules/elastic/common
