### PR TITLE
fix(env): normalize relative paths from config files

### DIFF
--- a/core/env/env.go
+++ b/core/env/env.go
@@ -255,7 +255,11 @@ func (env *Env) InitPaths(cfgPath string) error {
 		if cfgObj, err = config.LoadFile(cfgPath); err != nil {
 			return fmt.Errorf("error loading confiuration file: %v, %w", cfgPath, err)
 		}
-		return cfgObj.Unpack(&env.SystemConfig)
+		if err := cfgObj.Unpack(&env.SystemConfig); err != nil {
+			return err
+		}
+		env.normalizeRelativePaths()
+		return nil
 	} else {
 		if !env.IgnoreOnConfigMissing {
 			return errors.Errorf("config file %v not found", cfgPath)
@@ -418,6 +422,7 @@ func (env *Env) loadEnvFromConfigFile(filename string) error {
 	}
 
 	env.SystemConfig = &tempCfg
+	env.normalizeRelativePaths()
 	//initialize node config
 	env.findWorkingDir()
 
@@ -479,6 +484,30 @@ func (env *Env) loadEnvFromConfigFile(filename string) error {
 	moduleConfig = parseModuleConfig(env.SystemConfig.Modules)
 
 	return nil
+}
+
+func resolvePathRelativeToExecutable(p string) string {
+	p = strings.TrimSpace(p)
+	if p == "" || filepath.IsAbs(p) {
+		return p
+	}
+
+	executablePath, err := os.Executable()
+	if err != nil {
+		return p
+	}
+	return filepath.Join(filepath.Dir(executablePath), p)
+}
+
+func (env *Env) normalizeRelativePaths() {
+	if env.SystemConfig == nil {
+		return
+	}
+
+	env.SystemConfig.PathConfig.Config = resolvePathRelativeToExecutable(env.SystemConfig.PathConfig.Config)
+	env.SystemConfig.PathConfig.Data = resolvePathRelativeToExecutable(env.SystemConfig.PathConfig.Data)
+	env.SystemConfig.PathConfig.Log = resolvePathRelativeToExecutable(env.SystemConfig.PathConfig.Log)
+	env.SystemConfig.PathConfig.Plugin = resolvePathRelativeToExecutable(env.SystemConfig.PathConfig.Plugin)
 }
 
 func (env *Env) GetConfigFile() string {

--- a/core/env/env_test.go
+++ b/core/env/env_test.go
@@ -24,6 +24,8 @@
 package env
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -115,4 +117,25 @@ func TestParseConfigSection_KeyExistsButPrimitive_ReturnsError(t *testing.T) {
 
 	assert.False(t, exist)
 	require.Error(t, err)
+}
+
+func TestInitPathsNormalizesRelativePathsFromConfig(t *testing.T) {
+	executablePath, err := os.Executable()
+	require.NoError(t, err)
+
+	cfgFile, err := os.CreateTemp("", "env-paths-*.yml")
+	require.NoError(t, err)
+	defer os.Remove(cfgFile.Name())
+
+	_, err = cfgFile.WriteString("path.data: data\npath.log: log\npath.configs: config\n")
+	require.NoError(t, err)
+	require.NoError(t, cfgFile.Close())
+
+	env := EmptyEnv()
+	require.NoError(t, env.InitPaths(cfgFile.Name()))
+
+	executableDir := filepath.Dir(executablePath)
+	assert.Equal(t, filepath.Join(executableDir, "data"), env.SystemConfig.PathConfig.Data)
+	assert.Equal(t, filepath.Join(executableDir, "log"), env.SystemConfig.PathConfig.Log)
+	assert.Equal(t, filepath.Join(executableDir, "config"), env.SystemConfig.PathConfig.Config)
 }

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -25,6 +25,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add pluggable sink to host metrics collectors #288
 
 ### 🐛 Bug fix  
+- fix(env): normalize relative paths when loading config files (test: `go test ./core/env`) #334
 ### ✈️ Improvements  
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249


### PR DESCRIPTION
## Summary
- normalize relative path settings after loading config files into env.SystemConfig
- apply the same executable-relative path resolution during config refresh/load paths
- add focused env tests and release notes for the relative path normalization fix

## Testing
- go test ./core/env
