### PR TITLE
improve(elastic): derive hash partition counts from terms buckets

### DIFF
--- a/core/elastic/partition.go
+++ b/core/elastic/partition.go
@@ -401,7 +401,7 @@ func getPartitionsByHash(client API, indexName, fieldName string, partitionCount
 		})
 	}
 
-	counts, err := getPartitionDocCounts(client, indexName, partitions)
+	counts, err := getHashPartitionDocCounts(client, indexName, fieldName, partitionCount, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -415,6 +415,87 @@ func getPartitionsByHash(client API, indexName, fieldName string, partitionCount
 		filtered = append(filtered, partitions[idx])
 	}
 	return filtered, nil
+}
+
+func getHashPartitionDocCounts(client API, indexName, fieldName string, partitionCount int, filter interface{}) ([]int64, error) {
+	queryDsl := buildHashPartitionAggQuery(fieldName, partitionCount, filter)
+	res, err := searchPartitionWithRawQueryDSL(client, indexName, queryDsl)
+	if err != nil {
+		return nil, err
+	}
+	return extractHashPartitionDocCounts(res, partitionCount), nil
+}
+
+func buildHashPartitionAggQuery(fieldName string, partitionCount int, filter interface{}) util.MapStr {
+	fieldLiteral := buildPainlessStringLiteral(fieldName)
+	queryDsl := util.MapStr{
+		"size": 0,
+		"aggs": util.MapStr{
+			"partitions": util.MapStr{
+				"terms": util.MapStr{
+					"size":       partitionCount,
+					"value_type": "long",
+					"script": util.MapStr{
+						"lang":   "painless",
+						"source": fmt.Sprintf("if (doc[%s].size()==0 || doc[%s].value == '') return null; return (((doc[%s].value.hashCode() %% params.partition_count) + params.partition_count) %% params.partition_count);", fieldLiteral, fieldLiteral, fieldLiteral),
+						"params": util.MapStr{
+							"partition_count": partitionCount,
+						},
+					},
+				},
+			},
+		},
+	}
+	if filter != nil {
+		queryDsl["query"] = filter
+	}
+	return queryDsl
+}
+
+func extractHashPartitionDocCounts(res *SearchResponse, partitionCount int) []int64 {
+	counts := make([]int64, partitionCount)
+	if res == nil {
+		return counts
+	}
+	partitionsAgg, ok := res.Aggregations["partitions"]
+	if !ok {
+		return counts
+	}
+	for _, bucket := range partitionsAgg.Buckets {
+		bucketKey, ok := extractHashPartitionBucketKey(bucket["key"])
+		if !ok || bucketKey < 0 || bucketKey >= partitionCount {
+			continue
+		}
+		counts[bucketKey] = util.GetInt64Value(bucket["doc_count"])
+	}
+	return counts
+}
+
+func extractHashPartitionBucketKey(key interface{}) (int, bool) {
+	switch v := key.(type) {
+	case int:
+		return v, true
+	case int64:
+		return int(v), true
+	case int32:
+		return int(v), true
+	case uint:
+		return int(v), true
+	case uint64:
+		return int(v), true
+	case float64:
+		return int(v), true
+	case float32:
+		return int(v), true
+	case string:
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	default:
+		return 0, false
+	}
 }
 
 func getQuantileBoundaries(client API, indexName, fieldName string, partitionCount int, min, max float64, filter interface{}) ([]float64, error) {

--- a/core/elastic/partition_test.go
+++ b/core/elastic/partition_test.go
@@ -139,6 +139,64 @@ func TestBuildHashPartitionFilter(t *testing.T) {
 	}
 }
 
+func TestBuildHashPartitionAggQueryAppliesOuterFilter(t *testing.T) {
+	query := buildHashPartitionAggQuery("pmid.keyword", 8, util.MapStr{
+		"term": util.MapStr{
+			"env": util.MapStr{"value": "prod"},
+		},
+	})
+
+	if !reflect.DeepEqual(query["query"], util.MapStr{
+		"term": util.MapStr{
+			"env": util.MapStr{"value": "prod"},
+		},
+	}) {
+		t.Fatalf("expected outer filter to be applied at top-level query, got %v", query["query"])
+	}
+
+	termsAgg := query["aggs"].(util.MapStr)["partitions"].(util.MapStr)["terms"].(util.MapStr)
+	if got := termsAgg["size"]; got != 8 {
+		t.Fatalf("unexpected partition size: %v", got)
+	}
+	if got := termsAgg["value_type"]; got != "long" {
+		t.Fatalf("unexpected value_type: %v", got)
+	}
+	script := termsAgg["script"].(util.MapStr)
+	source, ok := script["source"].(string)
+	if !ok {
+		t.Fatalf("unexpected script source type: %T", script["source"])
+	}
+	if !strings.Contains(source, "return null") {
+		t.Fatalf("expected missing values to be skipped in hash aggregation, got %s", source)
+	}
+	if !strings.Contains(source, "value == ''") {
+		t.Fatalf("expected empty strings to be excluded in hash aggregation, got %s", source)
+	}
+	params := script["params"].(util.MapStr)
+	if got := params["partition_count"]; got != 8 {
+		t.Fatalf("unexpected partition_count: %v", got)
+	}
+}
+
+func TestExtractHashPartitionDocCountsMapsByBucketKey(t *testing.T) {
+	counts := extractHashPartitionDocCounts(&SearchResponse{
+		Aggregations: map[string]AggregationResponse{
+			"partitions": {
+				Buckets: []BucketBase{
+					{"key": float64(5), "doc_count": float64(12)},
+					{"key": "1", "doc_count": float64(7)},
+					{"key": float64(99), "doc_count": float64(3)},
+				},
+			},
+		},
+	}, 8)
+
+	expected := []int64{0, 7, 0, 0, 0, 12, 0, 0}
+	if !reflect.DeepEqual(counts, expected) {
+		t.Fatalf("unexpected hash counts: got %v want %v", counts, expected)
+	}
+}
+
 func TestBuildMissingFieldConditionIncludesEmptyString(t *testing.T) {
 	filter := buildMissingFieldCondition("pmid.keyword")
 	boolFilter, ok := filter["bool"].(util.MapStr)

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -29,6 +29,7 @@ Information about release notes of INFINI Framework is provided here.
 ### ✈️ Improvements  
 - improve(elastic): add hash and terms partition strategies (test: `go test ./core/elastic`) #327
 - improve(elastic): treat empty strings as missing in partition filters (test: `go test ./core/elastic`) #328
+- improve(elastic): derive hash partition counts from terms aggregation buckets (test: `go test ./core/elastic`) #335
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- compute hash partition document counts from the aggregation buckets directly instead of issuing one filter query per partition
- keep hash partition counting aligned with missing/empty-string handling in the aggregation script
- add focused core elastic tests and release notes for the hash partition counting improvement

## Testing
- go test ./core/elastic

## Stack
- depends on #329
