### PR TITLE
fix(elastic): skip system-cluster init before setup

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -25,6 +25,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add pluggable sink to host metrics collectors #288
 
 ### 🐛 Bug fix  
+- fix(elastic): skip system-cluster init before setup completes (test: `go test ./modules/elastic/...`) #336
 ### ✈️ Improvements  
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249

--- a/modules/elastic/module.go
+++ b/modules/elastic/module.go
@@ -112,10 +112,23 @@ func loadFileBasedElasticConfig() []elastic.ElasticsearchConfig {
 	return configs
 }
 
+func lookupSystemElasticsearchID() (string, bool) {
+	value := global.Lookup(elastic.GlobalSystemElasticsearchID)
+	systemID, ok := value.(string)
+	if !ok || systemID == "" {
+		return "", false
+	}
+	return systemID, true
+}
+
 func loadESBasedElasticConfig() []elastic.ElasticsearchConfig {
 	configs := []elastic.ElasticsearchConfig{}
+	systemID, ok := lookupSystemElasticsearchID()
+	if !ok {
+		return configs
+	}
 	query := elastic.SearchRequest{From: 0, Size: 1000} //TODO handle clusters beyond 1000
-	esClient := elastic.GetClient(global.MustLookupString(elastic.GlobalSystemElasticsearchID))
+	esClient := elastic.GetClient(systemID)
 	result, err := esClient.Search(orm.GetIndexName(elastic.ElasticsearchConfig{}), &query)
 	if err != nil {
 		log.Error(err)
@@ -394,20 +407,29 @@ func InitSchema() {
 var ormInited bool
 
 func (module *ElasticModule) Start() error {
+	systemID, hasSystemCluster := lookupSystemElasticsearchID()
 
 	if moduleConfig.ORMConfig.Enabled {
-		client := elastic.GetClient(global.MustLookupString(elastic.GlobalSystemElasticsearchID))
-		handler := ElasticORM{Client: client, Config: moduleConfig.ORMConfig}
-		orm.Register("elastic", &handler)
+		if !hasSystemCluster {
+			log.Warn("skip elastic ORM initialization, system cluster is not available")
+		} else {
+			client := elastic.GetClient(systemID)
+			handler := ElasticORM{Client: client, Config: moduleConfig.ORMConfig}
+			orm.Register("elastic", &handler)
+		}
 	}
 
 	if moduleConfig.StoreConfig.Enabled {
-		client := elastic.GetClient(global.MustLookupString(elastic.GlobalSystemElasticsearchID))
-		module.storeHandler = &ElasticStore{Client: client, Config: moduleConfig.StoreConfig}
-		kv.Register("elastic", module.storeHandler)
+		if !hasSystemCluster {
+			log.Warn("skip elastic store initialization, system cluster is not available")
+		} else {
+			client := elastic.GetClient(systemID)
+			module.storeHandler = &ElasticStore{Client: client, Config: moduleConfig.StoreConfig}
+			kv.Register("elastic", module.storeHandler)
+		}
 	}
 
-	if moduleConfig.ORMConfig.Enabled {
+	if moduleConfig.ORMConfig.Enabled && hasSystemCluster {
 		if !ormInited {
 			//init template
 			InitTemplate(false)
@@ -418,8 +440,12 @@ func (module *ElasticModule) Start() error {
 	}
 
 	if moduleConfig.RemoteConfigEnabled {
-		m := loadESBasedElasticConfig()
-		initElasticInstances(m, elastic.ElasticsearchConfigSourceElasticsearch)
+		if !hasSystemCluster {
+			log.Warn("skip remote elastic config loading, system cluster is not available")
+		} else {
+			m := loadESBasedElasticConfig()
+			initElasticInstances(m, elastic.ElasticsearchConfigSourceElasticsearch)
+		}
 	}
 
 	if module.storeHandler != nil {

--- a/modules/elastic/module_test.go
+++ b/modules/elastic/module_test.go
@@ -1,48 +1,48 @@
-// Copyright (C) INFINI Labs & INFINI LIMITED.
-//
-// The INFINI Framework is offered under the GNU Affero General Public License v3.0
-// and as commercial software.
-//
-// For commercial licensing, contact us at:
-//   - Website: infinilabs.com
-//   - Email: hello@infini.ltd
-//
-// Open Source licensed under AGPL V3:
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program. If not, see <http://www.gnu.org/licenses/>.
-
 package elastic
 
 import (
-	"fmt"
-	"github.com/buger/jsonparser"
-	"infini.sh/framework/core/util"
 	"testing"
+
+	coreElastic "infini.sh/framework/core/elastic"
+	"infini.sh/framework/core/global"
 )
 
-func TestV7GetClusterStates(t *testing.T) {
-	str := "{ \"_nodes\": { \"total\": 1, \"successful\": 1, \"failed\": 0 }, \"cluster_name\": \"es-v700\", \"cluster_uuid\": \"7NtDffC3RzGChhoOmgySig\", \"timestamp\": 1629611578327, \"status\": \"green\", \"indices\": { \"count\": 0, \"shards\": {}, \"docs\": { \"count\": 0, \"deleted\": 0 }, \"store\": { \"size_in_bytes\": 0 }, \"fielddata\": { \"memory_size_in_bytes\": 0, \"evictions\": 0 }, \"query_cache\": { \"memory_size_in_bytes\": 0, \"total_count\": 0, \"hit_count\": 0, \"miss_count\": 0, \"cache_size\": 0, \"cache_count\": 0, \"evictions\": 0 }, \"completion\": { \"size_in_bytes\": 0 }, \"segments\": { \"count\": 0, \"memory_in_bytes\": 0, \"terms_memory_in_bytes\": 0, \"stored_fields_memory_in_bytes\": 0, \"term_vectors_memory_in_bytes\": 0, \"norms_memory_in_bytes\": 0, \"points_memory_in_bytes\": 0, \"doc_values_memory_in_bytes\": 0, \"index_writer_memory_in_bytes\": 0, \"version_map_memory_in_bytes\": 0, \"fixed_bit_set_memory_in_bytes\": 0, \"max_unsafe_auto_id_timestamp\": -9223372036854776000, \"file_sizes\": {} } }, \"nodes\": { \"count\": { \"total\": 1, \"data\": 1, \"coordinating_only\": 0, \"master\": 1, \"ingest\": 1 }, \"versions\": [ \"7.0.0\" ], \"os\": { \"available_processors\": 24, \"allocated_processors\": 24, \"names\": [ { \"name\": \"Windows 10\", \"count\": 1 } ], \"pretty_names\": [ { \"pretty_name\": \"Windows 10\", \"count\": 1 } ], \"mem\": { \"total_in_bytes\": 137121308672, \"free_in_bytes\": 114813546496, \"used_in_bytes\": 22307762176, \"free_percent\": 84, \"used_percent\": 16 } }, \"process\": { \"cpu\": { \"percent\": 0 }, \"open_file_descriptors\": { \"min\": -1, \"max\": -1, \"avg\": 0 } }, \"jvm\": { \"max_uptime_in_millis\": 2021226, \"versions\": [ { \"version\": \"9.0.1.3\", \"vm_name\": \"OpenJDK 64-Bit Server VM\", \"vm_version\": \"9.0.1.3+11\", \"vm_vendor\": \"Azul Systems, Inc.\", \"bundled_jdk\": false, \"using_bundled_jdk\": null, \"count\": 1 } ], \"mem\": { \"heap_used_in_bytes\": 277003800, \"heap_max_in_bytes\": 1037959168 }, \"threads\": 66 }, \"fs\": { \"total_in_bytes\": 6000527532032, \"free_in_bytes\": 3111816585216, \"available_in_bytes\": 3111816585216 }, \"plugins\": [], \"network_types\": { \"transport_types\": { \"netty4\": 1 }, \"http_types\": { \"netty4\": 1 } }, \"discovery_types\": { \"zen\": 1 } } }"
+func TestLoadESBasedElasticConfigSkipsWhenSystemClusterUnavailable(t *testing.T) {
+	previous := global.Lookup(coreElastic.GlobalSystemElasticsearchID)
+	defer global.Register(coreElastic.GlobalSystemElasticsearchID, previous)
 
-	d1, err := jsonparser.GetInt(util.UnsafeStringToBytes(str), "indices", "segments", "max_unsafe_auto_id_timestamp")
-	fmt.Println("xv:", d1, err)
-	if err != nil {
-		d, err := jsonparser.Set(util.UnsafeStringToBytes(str), []byte("-1"), "indices", "segments", "max_unsafe_auto_id_timestamp")
-		if err == nil {
-			str = util.UnsafeBytesToString(d)
-		}
+	global.Register(coreElastic.GlobalSystemElasticsearchID, "")
+
+	configs := loadESBasedElasticConfig()
+	if len(configs) != 0 {
+		t.Fatalf("expected no remote configs when system cluster id is unavailable, got %d", len(configs))
 	}
-	d1, err = jsonparser.GetInt(util.UnsafeStringToBytes(str), "indices", "segments", "max_unsafe_auto_id_timestamp")
-	fmt.Println("xv:", d1, err)
-	//xv,err:=jsonparser.GetInt([]byte(str),"indices.segments.max_unsafe_auto_id_timestamp")
-	//fmt.Println("xv:",xv,err)
+}
+
+func TestElasticModuleStartSkipsSystemClusterDependentInitBeforeSetup(t *testing.T) {
+	previousSystemID := global.Lookup(coreElastic.GlobalSystemElasticsearchID)
+	defer global.Register(coreElastic.GlobalSystemElasticsearchID, previousSystemID)
+
+	previousModuleConfig := moduleConfig
+	defer func() {
+		moduleConfig = previousModuleConfig
+	}()
+
+	previousOrmInited := ormInited
+	defer func() {
+		ormInited = previousOrmInited
+	}()
+
+	global.Register(coreElastic.GlobalSystemElasticsearchID, "")
+
+	moduleConfig = getDefaultConfig()
+	moduleConfig.ORMConfig.Enabled = true
+	moduleConfig.StoreConfig.Enabled = true
+	moduleConfig.RemoteConfigEnabled = true
+	ormInited = false
+
+	module := &ElasticModule{}
+	if err := module.Start(); err != nil {
+		t.Fatalf("expected elastic module start to succeed before setup, got %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
- skip elastic ORM, store, and remote-config initialization until the system cluster ID is available
- avoid startup/setup failures before system-cluster bootstrapping has completed
- add focused elastic module tests and release notes for the pre-setup initialization guard

## Testing
- go test ./modules/elastic/...
