### PR TITLE
fix(bulk): advance buffered offsets before flush

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -25,6 +25,7 @@ Information about release notes of INFINI Framework is provided here.
 - feat: add pluggable sink to host metrics collectors #288
 
 ### 🐛 Bug fix  
+- fix(bulk): advance buffered offsets before immediate flushes (test: `go test ./plugins/elastic/bulk_indexing`) #337
 ### ✈️ Improvements  
 - improve(bulk): include summary counters in bulk processor debug exits (test: `go test ./plugins/elastic/bulk_indexing`) #356
 - improve(bulk): stop active queue detection after the processor stays idle (test: `go test ./plugins/elastic/bulk_indexing`) #355

--- a/plugins/elastic/bulk_indexing/bulk_indexing.go
+++ b/plugins/elastic/bulk_indexing/bulk_indexing.go
@@ -1021,6 +1021,10 @@ READ_DOCS:
 					mainBuf.WriteByteBuffer(pop.Data)
 				}
 
+				// Keep the in-memory offset aligned with the data already buffered.
+				// If the current message triggers an immediate flush, its NextOffset must be committed too.
+				offset = advanceBufferedOffset(pop.NextOffset)
+
 				if global.Env().IsDebug {
 					log.Tracef("slice worker, worker:[%v], message count: %v, size: %v", workerID, mainBuf.GetMessageCount(), util.ByteSize(uint64(mainBuf.GetMessageSize())))
 				}
@@ -1062,39 +1066,26 @@ READ_DOCS:
 							//continue //TODO, should panic? clear mainbuffer
 							panic(errors.Errorf("error on submit bulk_requests, queue:[%v], slice_id:%v, offset [%v]-[%v], bulk failed (host: %v, err: %v)", qConfig.ID, sliceID, committedOffset, offset, host, err))
 						} else {
-							if offset != nil && committedOffset != nil && !offset.Equals(*committedOffset) {
-								err := consumerInstance.CommitOffset(*offset)
-								if err != nil {
-									log.Errorf("🔧 offset commit failed, worker:[%v], queue:[%v], slice:[%v], offset:[%v], err:%v", workerID, qConfig.Name, sliceID, *offset, err)
-									panic(err)
-								}
-
-								if global.Env().IsDebug {
-									log.Tracef("slice worker, worker:[%v], [%v][%v][%v][%v] success commit offset:%v,ctx:%v,timeout:%v,err:%v", workerID, qConfig.Name, consumerConfig.Group, consumerConfig.Name, sliceID, *offset, committedOffset, ctx1.String(), timeout, err)
-								}
-								// fix: update committedOffset immediately after successful commit, to ensure state consistency
-								committedOffset = offset
-								log.Debugf("🔧 offset committed successfully, worker:[%v], queue:[%v], slice:[%v], offset:[%v]", workerID, qConfig.Name, sliceID, *offset)
-							} else {
-								if global.Env().IsDebug {
-									log.Debugf("🔧 offset not changed, skip commit, worker:[%v], queue:[%v], slice:[%v], offset:[%v], committed:[%v]", workerID, qConfig.Name, sliceID, offset, committedOffset)
-								}
+							committed, commitErr := commitBufferedOffset(consumerInstance, offset, &committedOffset)
+							if commitErr != nil {
+								log.Errorf("🔧 offset commit failed, worker:[%v], queue:[%v], slice:[%v], offset:[%v], err:%v", workerID, qConfig.Name, sliceID, *offset, commitErr)
+								panic(commitErr)
 							}
-							// fix: this code is moved to loop outside (line 970) to avoid updating offset in the middle of bulk submission
-							// offset = &pop.NextOffset
+
+							if committed {
+								if global.Env().IsDebug {
+									log.Tracef("slice worker, worker:[%v], [%v][%v][%v][%v] success commit offset:%v,ctx:%v,timeout:%v,err:%v", workerID, qConfig.Name, consumerConfig.Group, consumerConfig.Name, sliceID, *offset, committedOffset, ctx1.String(), timeout, commitErr)
+								}
+								log.Debugf("🔧 offset committed successfully, worker:[%v], queue:[%v], slice:[%v], offset:[%v]", workerID, qConfig.Name, sliceID, *offset)
+							} else if global.Env().IsDebug {
+								log.Debugf("🔧 offset not changed, skip commit, worker:[%v], queue:[%v], slice:[%v], offset:[%v], committed:[%v]", workerID, qConfig.Name, sliceID, offset, committedOffset)
+							}
 						}
 					} else {
 						log.Errorf("should not submit this bulk request, worker[%v], queue:[%v], slice:[%v], offset:[%v]->[%v],%v, msg:%v", workerID, qConfig.ID, sliceID, committedOffset, offset, err, msgCount)
 					}
 				}
-
-				// fix: update offset after each message is processed, to ensure progress sync with actual processing
-				// so even if it crashes before submission, it will not repeat processing messages written to the buffer after restart
-				offset = &pop.NextOffset
 			}
-
-			// fix: remove this code to avoid overwriting the updated offset in the loop
-			// offset = &ctx1.NextOffset
 		}
 
 		if time.Since(lastCommit) > idleDuration && mainBuf.GetMessageSize() > 0 {
@@ -1142,15 +1133,12 @@ CLEAN_BUFFER:
 			}
 
 			if continueNext {
-				if offset != nil && committedOffset != nil && !offset.Equals(*committedOffset) {
-					err := consumerInstance.CommitOffset(*offset)
-					if err != nil {
-						panic(err)
-					}
-					committedOffset = offset
-					if global.Env().IsDebug {
-						log.Tracef("slice worker, worker:[%v], [%v][%v][%v][%v] commit offset:%v,ctx:%v,err:%v", workerID, qConfig.Name, consumerConfig.Group, consumerConfig.Name, sliceID, offset, ctx1.String(), err)
-					}
+				committed, commitErr := commitBufferedOffset(consumerInstance, offset, &committedOffset)
+				if commitErr != nil {
+					panic(commitErr)
+				}
+				if committed && global.Env().IsDebug {
+					log.Tracef("slice worker, worker:[%v], [%v][%v][%v][%v] commit offset:%v,ctx:%v,err:%v", workerID, qConfig.Name, consumerConfig.Group, consumerConfig.Name, sliceID, offset, ctx1.String(), commitErr)
 				}
 			} else {
 				//logging failure offset boundry
@@ -1281,6 +1269,24 @@ func appendStrArr(arr []string, size int, elems []string) []string {
 		return append(arr, elems[0:remaining]...)
 	}
 	return append(arr, elems...)
+}
+
+func advanceBufferedOffset(nextOffset queue.Offset) *queue.Offset {
+	next := nextOffset
+	return &next
+}
+
+func commitBufferedOffset(consumer queue.ConsumerAPI, offset *queue.Offset, committedOffset **queue.Offset) (bool, error) {
+	if consumer == nil || offset == nil || committedOffset == nil || *committedOffset == nil || offset.Equals(**committedOffset) {
+		return false, nil
+	}
+
+	if err := consumer.CommitOffset(*offset); err != nil {
+		return false, err
+	}
+
+	*committedOffset = offset
+	return true, nil
 }
 
 func (processor *BulkIndexingProcessor) getElasticsearchMetadata(qConfig *queue.QueueConfig) (string, *elastic.ElasticsearchMetadata) {

--- a/plugins/elastic/bulk_indexing/bulk_indexing_test.go
+++ b/plugins/elastic/bulk_indexing/bulk_indexing_test.go
@@ -31,6 +31,7 @@ import (
 	stdErrors "errors"
 	"github.com/OneOfOne/xxhash"
 	"github.com/stretchr/testify/assert"
+	"infini.sh/framework/core/queue"
 	"sync"
 	"testing"
 	"time"
@@ -162,4 +163,64 @@ func TestShouldQuitActiveQueueDetection(t *testing.T) {
 	assert.False(t, shouldQuitActiveQueueDetection(time.Now().Add(-9*time.Second), 5*time.Second, 5*time.Second, 0))
 	assert.True(t, shouldQuitActiveQueueDetection(time.Now().Add(-10*time.Second), 5*time.Second, 5*time.Second, 0))
 	assert.True(t, shouldQuitActiveQueueDetection(time.Now().Add(-5*time.Second), 5*time.Second, 0, 0))
+}
+
+func TestAdvanceBufferedOffsetUsesCurrentMessageNextOffset(t *testing.T) {
+	previousCommitted := queue.NewOffsetWithVersion(0, 100, 1)
+	currentNext := queue.NewOffsetWithVersion(0, 200, 1)
+
+	offset := advanceBufferedOffset(currentNext)
+
+	assert.NotNil(t, offset)
+	assert.True(t, offset.Equals(currentNext))
+	assert.False(t, offset.Equals(previousCommitted))
+}
+
+type stubBulkConsumer struct {
+	committed []queue.Offset
+}
+
+func (s *stubBulkConsumer) Close() error {
+	return nil
+}
+
+func (s *stubBulkConsumer) ResetOffset(segment, readPos int64) error {
+	return nil
+}
+
+func (s *stubBulkConsumer) FetchMessages(ctx *queue.Context, numOfMessages int) (messages []queue.Message, isTimeout bool, err error) {
+	return nil, false, nil
+}
+
+func (s *stubBulkConsumer) CommitOffset(offset queue.Offset) error {
+	s.committed = append(s.committed, offset)
+	return nil
+}
+
+func TestCommitBufferedOffsetUsesCurrentMessageNextOffset(t *testing.T) {
+	consumer := &stubBulkConsumer{}
+	committedOffset := advanceBufferedOffset(queue.NewOffsetWithVersion(0, 100, 1))
+	currentNext := queue.NewOffsetWithVersion(0, 200, 1)
+	offset := advanceBufferedOffset(currentNext)
+
+	committed, err := commitBufferedOffset(consumer, offset, &committedOffset)
+
+	assert.NoError(t, err)
+	assert.True(t, committed)
+	if assert.Len(t, consumer.committed, 1) {
+		assert.True(t, consumer.committed[0].Equals(currentNext))
+	}
+	assert.True(t, committedOffset.Equals(currentNext))
+}
+
+func TestCommitBufferedOffsetSkipsUnchangedOffset(t *testing.T) {
+	consumer := &stubBulkConsumer{}
+	committedOffset := advanceBufferedOffset(queue.NewOffsetWithVersion(0, 100, 1))
+	offset := advanceBufferedOffset(queue.NewOffsetWithVersion(0, 100, 1))
+
+	committed, err := commitBufferedOffset(consumer, offset, &committedOffset)
+
+	assert.NoError(t, err)
+	assert.False(t, committed)
+	assert.Empty(t, consumer.committed)
 }


### PR DESCRIPTION
## Summary
- advance the in-memory bulk offset as soon as a message is buffered so immediate flushes commit the right next offset
- add focused bulk indexing coverage for the buffered-offset helper
- add release notes for the bulk offset correctness fix

## Testing
- go test ./plugins/elastic/bulk_indexing
