### PR TITLE
improve(elastic): add unavailable-cluster debug reasons

### DIFF
--- a/core/elastic/actions.go
+++ b/core/elastic/actions.go
@@ -118,10 +118,33 @@ func (node *NodeAvailable) IsDead() bool {
 }
 
 func (meta *ElasticsearchMetadata) IsAvailable() bool {
-	if meta.Config == nil || !meta.Config.Enabled {
+	if meta.Config == nil {
+		if rate.GetRateLimiter("cluster_available_check", "nil_config", 1, 1, 30*time.Second).Allow() {
+			log.Debug("elasticsearch metadata is unavailable: config is nil")
+		}
 		return false
 	}
-	return meta.clusterAvailable
+	if !meta.Config.Enabled {
+		clusterID := meta.Config.ID
+		if clusterID == "" {
+			clusterID = meta.Config.Name
+		}
+		if rate.GetRateLimiter("cluster_available_check", clusterID, 1, 1, 30*time.Second).Allow() {
+			log.Debugf("elasticsearch [%v] is unavailable: config disabled", meta.Config.Name)
+		}
+		return false
+	}
+	if !meta.clusterAvailable {
+		clusterID := meta.Config.ID
+		if clusterID == "" {
+			clusterID = meta.Config.Name
+		}
+		if rate.GetRateLimiter("cluster_available_check", clusterID, 1, 1, 30*time.Second).Allow() {
+			log.Debugf("elasticsearch [%v] is unavailable: clusterAvailable=false", meta.Config.Name)
+		}
+		return false
+	}
+	return true
 }
 
 func (meta *ElasticsearchMetadata) Init(health bool) {

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- improve(elastic): add rate-limited debug reasons for unavailable clusters (test: `go test ./core/elastic`) #339
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- add rate-limited debug logs that explain why an elastic cluster is currently unavailable
- keep availability behavior unchanged while surfacing nil-config, disabled, and clusterAvailable=false cases
- add release notes for the extra cluster availability diagnostics

## Testing
- go test ./core/elastic
