### PR TITLE
improve(queue): default delete_after_compress to true

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- improve(queue): default delete_after_compress to true (test: `go test ./modules/queue/disk_queue`) #340
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/modules/queue/disk_queue/module.go
+++ b/modules/queue/disk_queue/module.go
@@ -246,7 +246,7 @@ func (module *DiskQueue) Setup() {
 		PrepareFilesToRead:              true,
 		Compress: DiskCompress{
 			IdleThreshold:             3,
-			DeleteAfterCompress:       false,
+			DeleteAfterCompress:       true,
 			NumOfFilesDecompressAhead: 3,
 			Message: CompressConfig{
 				Enabled: false,

--- a/modules/queue/disk_queue/module_test.go
+++ b/modules/queue/disk_queue/module_test.go
@@ -1,0 +1,20 @@
+package queue
+
+import (
+	"testing"
+
+	. "infini.sh/framework/core/env"
+	"infini.sh/framework/core/global"
+)
+
+func TestSetupDefaultsDeleteAfterCompress(t *testing.T) {
+	env1 := EmptyEnv()
+	global.RegisterEnv(env1)
+
+	module := DiskQueue{}
+	module.Setup()
+
+	if !module.cfg.Compress.DeleteAfterCompress {
+		t.Fatalf("delete_after_compress should default to true")
+	}
+}


### PR DESCRIPTION
## Summary
- default disk queue compress.delete_after_compress to true
- add focused queue module coverage for the default compress cleanup behavior
- add release notes for the safer compress cleanup default

## Testing
- go test ./modules/queue/disk_queue
