### PR TITLE
improve(api): expose registered UI router dispatch

### DIFF
--- a/core/api/web.go
+++ b/core/api/web.go
@@ -30,6 +30,7 @@ package api
 import (
 	ctx "context"
 	"crypto/tls"
+	"fmt"
 	"net/http"
 	_ "net/http/pprof"
 	"runtime"
@@ -55,6 +56,14 @@ var uiServeMux *http.ServeMux
 var uiMutex sync.Mutex
 
 var bindAddress string
+
+func ServeRegisteredUIRequest(w http.ResponseWriter, req *http.Request) error {
+	if uiRouter == nil {
+		return fmt.Errorf("web router is not initialized")
+	}
+	uiRouter.ServeHTTP(w, req)
+	return nil
+}
 
 func StopWeb(cfg config.WebAppConfig) {
 	if srv != nil {

--- a/core/api/web_test.go
+++ b/core/api/web_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	httprouter "infini.sh/framework/core/api/router"
+)
+
+func TestServeRegisteredUIRequestRequiresRouter(t *testing.T) {
+	previous := uiRouter
+	uiRouter = nil
+	t.Cleanup(func() {
+		uiRouter = previous
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/ui", nil)
+	resp := httptest.NewRecorder()
+
+	err := ServeRegisteredUIRequest(resp, req)
+	if err == nil {
+		t.Fatal("expected error when ui router is not initialized")
+	}
+	if !strings.Contains(err.Error(), "web router is not initialized") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestServeRegisteredUIRequestDispatchesToRouter(t *testing.T) {
+	previous := uiRouter
+	router := httprouter.New(http.NewServeMux())
+	router.Handle(http.MethodGet, "/ui", func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		_, _ = w.Write([]byte("ok"))
+	})
+	uiRouter = router
+	t.Cleanup(func() {
+		uiRouter = previous
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/ui", nil)
+	resp := httptest.NewRecorder()
+
+	err := ServeRegisteredUIRequest(resp, req)
+	if err != nil {
+		t.Fatalf("unexpected error serving ui request: %v", err)
+	}
+	if resp.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", resp.Code)
+	}
+	if body := resp.Body.String(); body != "ok" {
+		t.Fatalf("unexpected response body: %q", body)
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- improve(api): expose a helper to serve requests through the registered UI router (test: `go test ./core/api`) #341
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- expose a helper that serves requests through the initialized UI router
- add focused core/api coverage for the uninitialized and successful dispatch paths
- add release notes for the reusable UI router dispatch helper

## Testing
- go test ./core/api
