### PR TITLE
improve(configs): allow multiple reverse channel endpoints

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- improve(configs): allow multiple reverse channel endpoints in agent setup config (test: `go test ./modules/configs/common`) #342
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/modules/configs/common/config.go
+++ b/modules/configs/common/config.go
@@ -38,11 +38,12 @@ type AgentConfig struct {
 }
 
 type SetupConfig struct {
-	DownloadURL     string `config:"download_url"`
-	CACertFile      string `config:"ca_cert"`
-	CAKeyFile       string `config:"ca_key"`
-	ConsoleEndpoint string `config:"console_endpoint"`
-	Port            string `config:"port"`
+	DownloadURL             string   `config:"download_url"`
+	CACertFile              string   `config:"ca_cert"`
+	CAKeyFile               string   `config:"ca_key"`
+	ConsoleEndpoint         string   `config:"console_endpoint"`
+	ReverseChannelEndpoints []string `config:"reverse_channel_endpoints"`
+	Port                    string   `config:"port"`
 }
 
 func GetAgentConfig() *AgentConfig {

--- a/modules/configs/common/config_test.go
+++ b/modules/configs/common/config_test.go
@@ -1,0 +1,44 @@
+package common
+
+import (
+	"testing"
+
+	"infini.sh/framework/core/config"
+	coreenv "infini.sh/framework/core/env"
+)
+
+func TestParseAgentSetupReverseChannelEndpoints(t *testing.T) {
+	cfg, err := config.NewConfigFrom(map[string]interface{}{
+		"agent": map[string]interface{}{
+			"enabled": true,
+			"setup": map[string]interface{}{
+				"console_endpoint":          "https://console.example.org",
+				"reverse_channel_endpoints": []string{"wss://console.example.org/ws", "wss://console-backup.example.org/ws"},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("failed to build config: %v", err)
+	}
+
+	agentCfg := &AgentConfig{}
+	exists, err := coreenv.ParseConfigSection(cfg, "agent", agentCfg)
+	if err != nil {
+		t.Fatalf("failed to parse agent config: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected agent config to exist")
+	}
+	if agentCfg.Setup == nil {
+		t.Fatal("expected setup config to be parsed")
+	}
+	if len(agentCfg.Setup.ReverseChannelEndpoints) != 2 {
+		t.Fatalf("expected 2 reverse channel endpoints, got %d", len(agentCfg.Setup.ReverseChannelEndpoints))
+	}
+	if agentCfg.Setup.ReverseChannelEndpoints[0] != "wss://console.example.org/ws" {
+		t.Fatalf("unexpected first reverse channel endpoint: %q", agentCfg.Setup.ReverseChannelEndpoints[0])
+	}
+	if agentCfg.Setup.ReverseChannelEndpoints[1] != "wss://console-backup.example.org/ws" {
+		t.Fatalf("unexpected second reverse channel endpoint: %q", agentCfg.Setup.ReverseChannelEndpoints[1])
+	}
+}


### PR DESCRIPTION
## Summary
- allow agent setup config to expose multiple reverse channel endpoints instead of a single endpoint
- add focused config parsing coverage for the reverse channel endpoint list
- add release notes for the new agent setup config shape

## Testing
- go test ./modules/configs/common
