### PR TITLE
improve(model): fall back to web endpoint when API is disabled

### DIFF
--- a/core/model/instance.go
+++ b/core/model/instance.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	log "github.com/cihub/seelog"
+	"infini.sh/framework/core/config"
 	"infini.sh/framework/core/env"
 	"infini.sh/framework/core/global"
 	"infini.sh/framework/core/host"
@@ -126,6 +127,16 @@ func (inst *Instance) GetVersion() (map[string]interface{}, error) {
 	return nil, fmt.Errorf("unknow agent version")
 }
 
+func resolveManagedInstanceEndpoint(apiConfig config.APIConfig, webConfig config.WebAppConfig) string {
+	if apiConfig.Enabled {
+		return apiConfig.GetEndpoint()
+	}
+	if webConfig.Enabled {
+		return webConfig.GetEndpoint()
+	}
+	return apiConfig.GetEndpoint()
+}
+
 func GetInstanceInfo() Instance {
 	instance := Instance{}
 	instance.ID = global.Env().SystemConfig.NodeConfig.ID
@@ -137,7 +148,7 @@ func GetInstanceInfo() Instance {
 
 	_, publicIP, _, _ := util.GetPublishNetworkDeviceInfo(global.Env().SystemConfig.NodeConfig.MajorIpPattern)
 
-	instance.Endpoint = global.Env().SystemConfig.APIConfig.GetEndpoint()
+	instance.Endpoint = resolveManagedInstanceEndpoint(global.Env().SystemConfig.APIConfig, global.Env().SystemConfig.WebAppConfig)
 
 	ips := util.GetLocalIPs()
 	if len(ips) > 0 {

--- a/core/model/instance_test.go
+++ b/core/model/instance_test.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"testing"
+
+	"infini.sh/framework/core/config"
+)
+
+func TestResolveManagedInstanceEndpoint(t *testing.T) {
+	t.Run("prefer api endpoint when api is enabled", func(t *testing.T) {
+		apiConfig := config.APIConfig{Enabled: true}
+		apiConfig.NetworkConfig.Publish = "127.0.0.1:2900"
+		webConfig := config.WebAppConfig{Enabled: true}
+		webConfig.NetworkConfig.Publish = "127.0.0.1:8080"
+
+		endpoint := resolveManagedInstanceEndpoint(apiConfig, webConfig)
+		if endpoint != "http://127.0.0.1:2900" {
+			t.Fatalf("unexpected endpoint: %s", endpoint)
+		}
+	})
+
+	t.Run("fallback to web endpoint when api is disabled", func(t *testing.T) {
+		apiConfig := config.APIConfig{Enabled: false}
+		apiConfig.NetworkConfig.Publish = "127.0.0.1:2900"
+		webConfig := config.WebAppConfig{Enabled: true}
+		webConfig.NetworkConfig.Publish = "127.0.0.1:8080"
+
+		endpoint := resolveManagedInstanceEndpoint(apiConfig, webConfig)
+		if endpoint != "http://127.0.0.1:8080" {
+			t.Fatalf("unexpected endpoint: %s", endpoint)
+		}
+	})
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- improve(model): fall back to the web endpoint when managed API is disabled (test: `go test ./core/model`) #343
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- prefer the API endpoint for managed instances when it is enabled
- fall back to the web endpoint when the API listener is disabled
- add focused core/model coverage and release notes for the endpoint selection helper

## Testing
- go test ./core/model
