### PR TITLE
improve(api): expose registered API dispatch

### DIFF
--- a/core/api/api.go
+++ b/core/api/api.go
@@ -136,6 +136,35 @@ func HandleAPIMethod(method Method, pattern string, handler func(w http.Response
 	l.Unlock()
 }
 
+func ServeRegisteredAPIRequest(w http.ResponseWriter, req *http.Request) {
+	localMux := http.NewServeMux()
+	localRouter := httprouter.New(localMux)
+	localRouter.NotFound = notfoundHandler
+
+	l.Lock()
+	defer l.Unlock()
+
+	for pattern, handler := range registeredAPIFuncHandler {
+		wrapped := handler
+		for _, f := range filters {
+			wrapped = f.FilterHttpHandlerFunc(pattern, wrapped)
+		}
+		localMux.HandleFunc(pattern, wrapped)
+	}
+
+	for method, handlers := range registeredAPIMethodHandler {
+		for pattern, handler := range handlers {
+			wrapped := handler
+			for _, f := range filters {
+				wrapped = f.FilterHttpRouter(pattern, wrapped)
+			}
+			localRouter.Handle(method, pattern, wrapped)
+		}
+	}
+
+	localRouter.ServeHTTP(w, req)
+}
+
 var router = httprouter.New(mux)
 var mux = http.NewServeMux()
 

--- a/core/api/api_test.go
+++ b/core/api/api_test.go
@@ -27,9 +27,12 @@
 package api
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	httprouter "infini.sh/framework/core/api/router"
 )
 
 func TestStripPrefix(t *testing.T) {
@@ -109,5 +112,25 @@ func TestStripPrefix(t *testing.T) {
 					receivedPath, tc.expectedPathInHandler)
 			}
 		})
+	}
+}
+
+func TestServeRegisteredAPIRequest(t *testing.T) {
+	path := fmt.Sprintf("/__copilot_test__/api/%s/:id", t.Name())
+	HandleAPIMethod(GET, path, func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(ps.MustGetParameter("id") + ":" + req.URL.Query().Get("q")))
+	})
+
+	req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/__copilot_test__/api/%s/value?q=ok", t.Name()), nil)
+	recorder := httptest.NewRecorder()
+
+	ServeRegisteredAPIRequest(recorder, req)
+
+	if recorder.Code != http.StatusAccepted {
+		t.Fatalf("unexpected status: %d", recorder.Code)
+	}
+	if recorder.Body.String() != "value:ok" {
+		t.Fatalf("unexpected body: %s", recorder.Body.String())
 	}
 }

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- improve(api): expose a helper to serve requests through registered API handlers (test: `go test ./core/api`) #344
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- expose a helper that serves requests through the registered API handlers
- add focused core/api coverage for path params and query strings through the helper
- add release notes for the reusable API dispatch helper

## Testing
- go test ./core/api
