### PR TITLE
improve(model): publish managed instance service endpoints

### DIFF
--- a/core/model/instance.go
+++ b/core/model/instance.go
@@ -137,6 +137,23 @@ func resolveManagedInstanceEndpoint(apiConfig config.APIConfig, webConfig config
 	return apiConfig.GetEndpoint()
 }
 
+func buildManagedInstanceServices(apiConfig config.APIConfig, webConfig config.WebAppConfig) []ServiceInfo {
+	services := []ServiceInfo{}
+	if apiConfig.Enabled {
+		services = append(services, ServiceInfo{
+			Name:     "api",
+			Endpoint: apiConfig.GetEndpoint(),
+		})
+	}
+	if webConfig.Enabled {
+		services = append(services, ServiceInfo{
+			Name:     "web",
+			Endpoint: webConfig.GetEndpoint(),
+		})
+	}
+	return services
+}
+
 func GetInstanceInfo() Instance {
 	instance := Instance{}
 	instance.ID = global.Env().SystemConfig.NodeConfig.ID
@@ -149,6 +166,7 @@ func GetInstanceInfo() Instance {
 	_, publicIP, _, _ := util.GetPublishNetworkDeviceInfo(global.Env().SystemConfig.NodeConfig.MajorIpPattern)
 
 	instance.Endpoint = resolveManagedInstanceEndpoint(global.Env().SystemConfig.APIConfig, global.Env().SystemConfig.WebAppConfig)
+	instance.Services = buildManagedInstanceServices(global.Env().SystemConfig.APIConfig, global.Env().SystemConfig.WebAppConfig)
 
 	ips := util.GetLocalIPs()
 	if len(ips) > 0 {

--- a/core/model/instance_test.go
+++ b/core/model/instance_test.go
@@ -31,3 +31,21 @@ func TestResolveManagedInstanceEndpoint(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildManagedInstanceServices(t *testing.T) {
+	apiConfig := config.APIConfig{Enabled: true}
+	apiConfig.NetworkConfig.Publish = "127.0.0.1:2900"
+	webConfig := config.WebAppConfig{Enabled: true}
+	webConfig.NetworkConfig.Publish = "127.0.0.1:8080"
+
+	services := buildManagedInstanceServices(apiConfig, webConfig)
+	if len(services) != 2 {
+		t.Fatalf("unexpected service count: %#v", services)
+	}
+	if services[0].Name != "api" || services[0].Endpoint != "http://127.0.0.1:2900" {
+		t.Fatalf("unexpected api service: %#v", services[0])
+	}
+	if services[1].Name != "web" || services[1].Endpoint != "http://127.0.0.1:8080" {
+		t.Fatalf("unexpected web service: %#v", services[1])
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- improve(model): publish api and web service endpoints in managed instance info (test: `go test ./core/model`) #345
 - improve(model): fall back to the web endpoint when managed API is disabled (test: `go test ./core/model`) #343
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249


### PR DESCRIPTION
## Summary
- publish both api and web service endpoints in managed instance info when those listeners are enabled
- keep the primary endpoint selection unchanged from the fallback helper in #343
- add focused core/model coverage and release notes for the managed service endpoint list

## Testing
- go test ./core/model
