### PR TITLE
fix(metrics): reconfigure collectors when collection mode changes

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- fix(metrics): reconfigure collectors when metric collection mode changes (test: `go test ./modules/metrics/...`) #347
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/modules/metrics/elastic/elasticsearch.go
+++ b/modules/metrics/elastic/elasticsearch.go
@@ -127,6 +127,24 @@ func validateMonitorConfig(monitorConfig *elastic.TaskConfig) {
 	}
 }
 
+func (m *ElasticsearchMetric) shouldCollectMetrics(v *elastic.ElasticsearchMetadata) bool {
+	if v == nil || v.Config == nil {
+		return false
+	}
+	if !v.Config.Monitored || !v.Config.Enabled {
+		return false
+	}
+	if !m.IsAgentMode && v.Config.MetricCollectionMode == elastic.ModeAgent {
+		log.Debugf("cluster [%v] is in agent mode, skip console-side metric collection", v.Config.Name)
+		return false
+	}
+	if m.IsAgentMode && v.Config.MetricCollectionMode == elastic.ModeAgentless {
+		log.Debugf("cluster [%v] is in agentless mode, skip agent-side metric collection", v.Config.Name)
+		return false
+	}
+	return true
+}
+
 func (m *ElasticsearchMetric) Collect() error {
 	if !m.Enabled {
 		return nil
@@ -192,8 +210,8 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 			m.RemoveTask(taskID)
 		}
 	}
-	if !v.Config.Monitored || !v.Config.Enabled {
-		log.Debugf("cluster [%v] NOT (enabled[%v] or monitored[%v] or not available[%v]), skip collect", v.Config.Name, v.Config.Enabled, v.Config.Monitored, v.IsAvailable())
+	if !m.shouldCollectMetrics(v) {
+		log.Debugf("cluster [%v] NOT eligible for metrics collection (enabled[%v], monitored[%v], mode[%v], available[%v]), skip collect", v.Config.Name, v.Config.Enabled, v.Config.Monitored, v.Config.MetricCollectionMode, v.IsAvailable())
 		return true
 	}
 	if global.Env().IsDebug {

--- a/modules/metrics/elastic/elasticsearch_test.go
+++ b/modules/metrics/elastic/elasticsearch_test.go
@@ -1,0 +1,39 @@
+package elastic
+
+import (
+	"testing"
+
+	coreelastic "infini.sh/framework/core/elastic"
+)
+
+func TestShouldCollectMetricsSkipsConsoleCollectorInAgentMode(t *testing.T) {
+	collector := &ElasticsearchMetric{}
+	meta := &coreelastic.ElasticsearchMetadata{
+		Config: &coreelastic.ElasticsearchConfig{
+			Name:                 "agent-cluster",
+			Enabled:              true,
+			Monitored:            true,
+			MetricCollectionMode: coreelastic.ModeAgent,
+		},
+	}
+
+	if collector.shouldCollectMetrics(meta) {
+		t.Fatal("expected console-side collector to skip clusters in agent mode")
+	}
+}
+
+func TestShouldCollectMetricsAllowsConsoleCollectorInAgentlessMode(t *testing.T) {
+	collector := &ElasticsearchMetric{}
+	meta := &coreelastic.ElasticsearchMetadata{
+		Config: &coreelastic.ElasticsearchConfig{
+			Name:                 "agentless-cluster",
+			Enabled:              true,
+			Monitored:            true,
+			MetricCollectionMode: coreelastic.ModeAgentless,
+		},
+	}
+
+	if !collector.shouldCollectMetrics(meta) {
+		t.Fatal("expected console-side collector to run for agentless clusters")
+	}
+}

--- a/modules/metrics/metrics.go
+++ b/modules/metrics/metrics.go
@@ -115,7 +115,8 @@ func (module *MetricsModule) Setup() {
 				// check other conditions
 				hasChanged = meta.IsAvailable() != oldMeta.IsAvailable() ||
 					meta.Config.Enabled != oldMeta.Config.Enabled ||
-					meta.Config.Monitored != oldMeta.Config.Monitored
+					meta.Config.Monitored != oldMeta.Config.Monitored ||
+					meta.Config.MetricCollectionMode != oldMeta.Config.MetricCollectionMode
 			}
 			if !hasChanged {
 				return


### PR DESCRIPTION
## Summary
- re-evaluate elastic metric tasks when metric collection mode changes
- gate console and agent metric collection based on the configured collection mode
- add focused metrics tests and release notes for collection-mode task refresh

## Testing
- go test ./modules/metrics/...
