### PR TITLE
fix(metrics): keep cluster-level collection on console in agent mode

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- fix(metrics): keep cluster-level collection on console for agent-mode clusters (test: `go test ./modules/metrics/...`) #348
 - fix(metrics): reconfigure collectors when metric collection mode changes (test: `go test ./modules/metrics/...`) #347
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249

--- a/modules/metrics/elastic/elasticsearch.go
+++ b/modules/metrics/elastic/elasticsearch.go
@@ -134,12 +134,23 @@ func (m *ElasticsearchMetric) shouldCollectMetrics(v *elastic.ElasticsearchMetad
 	if !v.Config.Monitored || !v.Config.Enabled {
 		return false
 	}
-	if !m.IsAgentMode && v.Config.MetricCollectionMode == elastic.ModeAgent {
-		log.Debugf("cluster [%v] is in agent mode, skip console-side metric collection", v.Config.Name)
-		return false
-	}
 	if m.IsAgentMode && v.Config.MetricCollectionMode == elastic.ModeAgentless {
 		log.Debugf("cluster [%v] is in agentless mode, skip agent-side metric collection", v.Config.Name)
+		return false
+	}
+	return true
+}
+
+func (m *ElasticsearchMetric) shouldCollectClusterLevelMetrics(v *elastic.ElasticsearchMetadata) bool {
+	return m.shouldCollectMetrics(v)
+}
+
+func (m *ElasticsearchMetric) shouldCollectNodeAndIndexMetrics(v *elastic.ElasticsearchMetadata) bool {
+	if !m.shouldCollectMetrics(v) {
+		return false
+	}
+	if !m.IsAgentMode && v.Config.MetricCollectionMode == elastic.ModeAgent {
+		log.Debugf("cluster [%v] is in agent mode, skip console-side node/index metric collection", v.Config.Name)
 		return false
 	}
 	return true
@@ -220,7 +231,13 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 
 	var err error
 	monitorConfigs := getMonitorConfigs(v)
-	if m.ClusterHealth && monitorConfigs.ClusterHealth.Enabled {
+	clusterLevelEnabled := m.shouldCollectClusterLevelMetrics(v)
+	nodeAndIndexEnabled := m.shouldCollectNodeAndIndexMetrics(v)
+	if !clusterLevelEnabled && !nodeAndIndexEnabled {
+		log.Debugf("cluster [%v] has no eligible metric collectors (mode[%v], agent_mode[%v])", v.Config.Name, v.Config.MetricCollectionMode, m.IsAgentMode)
+		return true
+	}
+	if clusterLevelEnabled && m.ClusterHealth && monitorConfigs.ClusterHealth.Enabled {
 		log.Debugf("collect cluster health: %s, endpoint: %s", k, v.Config.GetAnyEndpoint())
 		var clusterHealthMetricTask = task.ScheduleTask{
 			ID:          clusterHealthTaskID,
@@ -244,7 +261,7 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 	}
 
 	//cluster stats
-	if m.ClusterStats && monitorConfigs.ClusterStats.Enabled {
+	if clusterLevelEnabled && m.ClusterStats && monitorConfigs.ClusterStats.Enabled {
 		log.Debugf("collect cluster state: %s, endpoint: %s", k, v.Config.GetAnyEndpoint())
 		var clusterStatsMetricTask = task.ScheduleTask{
 			ID:          clusterStatsTaskID,
@@ -268,7 +285,7 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 	}
 
 	//nodes stats
-	if m.NodeStats && monitorConfigs.NodeStats.Enabled {
+	if nodeAndIndexEnabled && m.NodeStats && monitorConfigs.NodeStats.Enabled {
 		var nodeStatsMetricTask = task.ScheduleTask{
 			ID:          nodeStatsTaskID,
 			Description: fmt.Sprintf("monitoring node stats metric for cluster %s", k),
@@ -344,7 +361,7 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 	}
 
 	//indices stats
-	if (m.AllIndexStats || m.IndexStats) && monitorConfigs.IndexStats.Enabled {
+	if nodeAndIndexEnabled && (m.AllIndexStats || m.IndexStats) && monitorConfigs.IndexStats.Enabled {
 		var indexStatsMetricTask = task.ScheduleTask{
 			ID:          indexStatsTaskID,
 			Description: fmt.Sprintf("monitoring index stats metric for cluster %s", k),

--- a/modules/metrics/elastic/elasticsearch_test.go
+++ b/modules/metrics/elastic/elasticsearch_test.go
@@ -6,7 +6,7 @@ import (
 	coreelastic "infini.sh/framework/core/elastic"
 )
 
-func TestShouldCollectMetricsSkipsConsoleCollectorInAgentMode(t *testing.T) {
+func TestShouldCollectMetricsAllowsConsoleCollectorInAgentModeForClusterLevelMetrics(t *testing.T) {
 	collector := &ElasticsearchMetric{}
 	meta := &coreelastic.ElasticsearchMetadata{
 		Config: &coreelastic.ElasticsearchConfig{
@@ -17,8 +17,11 @@ func TestShouldCollectMetricsSkipsConsoleCollectorInAgentMode(t *testing.T) {
 		},
 	}
 
-	if collector.shouldCollectMetrics(meta) {
-		t.Fatal("expected console-side collector to skip clusters in agent mode")
+	if !collector.shouldCollectMetrics(meta) {
+		t.Fatal("expected console-side collector to keep cluster-level metrics in agent mode")
+	}
+	if collector.shouldCollectNodeAndIndexMetrics(meta) {
+		t.Fatal("expected console-side collector to skip node/index metrics in agent mode")
 	}
 }
 
@@ -35,5 +38,40 @@ func TestShouldCollectMetricsAllowsConsoleCollectorInAgentlessMode(t *testing.T)
 
 	if !collector.shouldCollectMetrics(meta) {
 		t.Fatal("expected console-side collector to run for agentless clusters")
+	}
+	if !collector.shouldCollectNodeAndIndexMetrics(meta) {
+		t.Fatal("expected console-side collector to run node/index metrics for agentless clusters")
+	}
+}
+
+func TestShouldCollectMetricsSkipsAgentCollectorInAgentlessMode(t *testing.T) {
+	collector := &ElasticsearchMetric{IsAgentMode: true}
+	meta := &coreelastic.ElasticsearchMetadata{
+		Config: &coreelastic.ElasticsearchConfig{
+			Name:                 "agentless-cluster",
+			Enabled:              true,
+			Monitored:            true,
+			MetricCollectionMode: coreelastic.ModeAgentless,
+		},
+	}
+
+	if collector.shouldCollectMetrics(meta) {
+		t.Fatal("expected agent-side collector to skip agentless clusters")
+	}
+}
+
+func TestShouldCollectMetricsAllowsAgentCollectorInAgentMode(t *testing.T) {
+	collector := &ElasticsearchMetric{IsAgentMode: true}
+	meta := &coreelastic.ElasticsearchMetadata{
+		Config: &coreelastic.ElasticsearchConfig{
+			Name:                 "agent-cluster",
+			Enabled:              true,
+			Monitored:            true,
+			MetricCollectionMode: coreelastic.ModeAgent,
+		},
+	}
+
+	if !collector.shouldCollectMetrics(meta) {
+		t.Fatal("expected agent-side collector to run for agent mode clusters")
 	}
 }


### PR DESCRIPTION
## Summary
- keep cluster-level metrics eligible on the console for clusters configured in agent mode
- continue skipping node and index metrics on the console for agent-mode clusters
- add focused metrics tests and release notes for the agent-mode collection split

## Testing
- go test ./modules/metrics/...
