### PR TITLE
fix(adapter): fall back to config when cluster metadata is missing

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- fix(adapter): fall back to config when cluster metadata is missing (test: `go test ./modules/elastic/adapter`) #349
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/modules/elastic/adapter/ver.go
+++ b/modules/elastic/adapter/ver.go
@@ -170,6 +170,14 @@ func RequestTimeout(ctx *elastic.APIContext, method, url string, body []byte, me
 func GetClusterUUID(clusterID string) (string, error) {
 	meta := elastic.GetMetadata(clusterID)
 	if meta == nil {
+		if cfg := elastic.GetConfigNoPanic(clusterID); cfg != nil {
+			if cfg.ClusterUUID != "" {
+				return cfg.ClusterUUID, nil
+			}
+			meta = elastic.GetOrInitMetadata(cfg)
+		}
+	}
+	if meta == nil {
 		return "", fmt.Errorf("metadata can not be mepty")
 	}
 	if meta.ClusterState != nil {

--- a/modules/elastic/adapter/ver_test.go
+++ b/modules/elastic/adapter/ver_test.go
@@ -1,0 +1,30 @@
+package adapter
+
+import (
+	"testing"
+
+	"infini.sh/framework/core/elastic"
+	"infini.sh/framework/core/orm"
+)
+
+func TestGetClusterUUIDFallsBackToConfigWhenMetadataMissing(t *testing.T) {
+	cfg := elastic.ElasticsearchConfig{
+		ORMObjectBase: orm.ORMObjectBase{ID: "test-cluster-uuid-fallback"},
+		Name:          "test-cluster-uuid-fallback",
+		ClusterUUID:   "cluster-uuid-fallback",
+	}
+
+	t.Cleanup(func() {
+		elastic.RemoveInstance(cfg.ID)
+	})
+
+	elastic.UpdateConfig(cfg)
+
+	clusterUUID, err := GetClusterUUID(cfg.ID)
+	if err != nil {
+		t.Fatalf("expected cluster uuid from config fallback, got error: %v", err)
+	}
+	if clusterUUID != cfg.ClusterUUID {
+		t.Fatalf("expected cluster uuid %q, got %q", cfg.ClusterUUID, clusterUUID)
+	}
+}


### PR DESCRIPTION
## Summary
- fall back to the stored elastic config when cluster metadata has not been initialized yet
- avoid failing cluster UUID lookups when the config already carries a persisted cluster UUID
- add focused adapter coverage and release notes for the metadata fallback

## Testing
- go test ./modules/elastic/adapter
