### PR TITLE
fix(elastic): initialize metadata on first registration

### DIFF
--- a/core/elastic/domain_actions.go
+++ b/core/elastic/domain_actions.go
@@ -99,8 +99,14 @@ func RegisterInstance(cfg ElasticsearchConfig, handler API) {
 	UpdateClient(cfg, handler)
 	UpdateConfig(cfg)
 
+	meta := GetMetadata(cfg.ID)
+	if meta == nil {
+		InitMetadata(&cfg, false)
+		return
+	}
+
 	if exists && oldCfg != nil {
-		InitMetadata(&cfg, true)
+		InitMetadata(&cfg, meta.IsAvailable())
 	}
 }
 

--- a/core/elastic/domain_actions_test.go
+++ b/core/elastic/domain_actions_test.go
@@ -1,0 +1,35 @@
+package elastic
+
+import (
+	"testing"
+
+	"infini.sh/framework/core/orm"
+)
+
+func TestRegisterInstanceInitializesMetadataOnFirstRegistration(t *testing.T) {
+	cfg := ElasticsearchConfig{
+		ORMObjectBase: orm.ORMObjectBase{ID: "test-first-sync"},
+		Name:          "test-first-sync",
+		Enabled:       true,
+		ClusterUUID:   "cluster-uuid-1",
+	}
+
+	t.Cleanup(func() {
+		cfgs.Delete(cfg.ID)
+		apis.Delete(cfg.ID)
+		metas.Delete(cfg.ID)
+	})
+
+	RegisterInstance(cfg, nil)
+
+	meta := GetMetadata(cfg.ID)
+	if meta == nil {
+		t.Fatalf("expected metadata to be initialized for %s", cfg.ID)
+	}
+	if meta.Config == nil {
+		t.Fatalf("expected metadata config to be initialized for %s", cfg.ID)
+	}
+	if meta.Config.ClusterUUID != cfg.ClusterUUID {
+		t.Fatalf("expected cluster uuid %q, got %q", cfg.ClusterUUID, meta.Config.ClusterUUID)
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- fix(elastic): initialize metadata on first cluster registration (test: `go test ./core/elastic`) #351
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- initialize elastic metadata on the first cluster registration instead of waiting for an update path
- preserve the existing availability state when reinitializing metadata for later config updates
- add focused domain_actions coverage and release notes for the first-registration path

## Testing
- go test ./core/elastic
