### PR TITLE
improve(elastic): add creator metadata to common commands

### DIFF
--- a/core/elastic/common_command.go
+++ b/core/elastic/common_command.go
@@ -35,6 +35,7 @@ type CommonCommand struct {
 	ID       string           `json:"-" index:"id"`
 	Title    string           `json:"title" elastic_mapping:"title:{type:text,fields:{keyword:{type:keyword}}}"`
 	Tag      []string         `json:"tag" elastic_mapping:"tag:{type:keyword}"`
+	Creator  string           `json:"creator,omitempty" elastic_mapping:"creator:{type:keyword}"`
 	Requests []CommandRequest `json:"requests" elastic_mapping:"requests:{type:object}"`
 	Created  time.Time        `json:"created,omitempty" elastic_mapping:"created:{type:date}"`
 }

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- improve(elastic): add creator metadata to common saved commands (test: `go test ./core/elastic`) #352
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- add creator metadata to the shared elastic common command schema
- keep saved command documents ready to store the user or system identity that created them
- add release notes and validate the schema change with core/elastic tests

## Testing
- go test ./core/elastic
