### PR TITLE
fix(bulk): prevent duplicate queue consumers

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- fix(bulk): prevent duplicate queue consumers and keep conflicts visible (test: `go test ./plugins/elastic/bulk_indexing`) #353
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/plugins/elastic/bulk_indexing/bulk_indexing.go
+++ b/plugins/elastic/bulk_indexing/bulk_indexing.go
@@ -299,7 +299,7 @@ func (processor *BulkIndexingProcessor) Process(c *pipeline.Context) error {
 						}
 						//if have depth and not in in flight
 						if !processor.config.SkipEmptyQueue || queue.HasLag(v) {
-							_, ok := processor.inFlightQueueConfigs.Load(v.ID)
+							ok := processor.hasInFlightQueue(v.ID)
 							if !ok {
 								if global.Env().IsDebug {
 									log.Tracef("detecting new queue: %v", v.Name)
@@ -339,7 +339,7 @@ const queueHandleSingleton = "queue_handler_singleton"
 func (processor *BulkIndexingProcessor) HandleQueueConfig(v *queue.QueueConfig, parentContext *pipeline.Context) {
 
 	//TODO, add config to enable/disable singleton, may have performance issue
-	ok, _ := locker.Hold(queueHandleSingleton, v.ID, global.Env().SystemConfig.NodeConfig.ID, 60*time.Second, true)
+	ok, _ := locker.Hold(queueHandleSingleton, v.ID, processor.id, 60*time.Second, true)
 	if !ok {
 		log.Debugf("failed to hold lock for queue:[%v], already hold by somewhere", v.ID)
 		return
@@ -523,12 +523,31 @@ func (processor *BulkIndexingProcessor) reserveInFlightQueue(key, workerID strin
 	return workerID, true
 }
 
+func (processor *BulkIndexingProcessor) hasInFlightQueue(queueID string) bool {
+	if _, ok := processor.inFlightQueueConfigs.Load(queueID); ok {
+		return true
+	}
+
+	queuePrefix := fmt.Sprintf("%v-", queueID)
+	hasInFlight := false
+	processor.inFlightQueueConfigs.Range(func(key, value interface{}) bool {
+		keyStr, ok := key.(string)
+		if ok && strings.HasPrefix(keyStr, queuePrefix) {
+			hasInFlight = true
+			return false
+		}
+		return true
+	})
+
+	return hasInFlight
+}
+
 func isIgnorableAcquireConsumerError(err error) bool {
 	if err == nil {
 		return false
 	}
 
-	return util.ContainStr(err.Error(), "already owning this topic") || util.ContainStr(err.Error(), "the consumer is in fighting list")
+	return util.ContainStr(err.Error(), "already owning this topic")
 }
 
 var xxHashPool = sync.Pool{

--- a/plugins/elastic/bulk_indexing/bulk_indexing.go
+++ b/plugins/elastic/bulk_indexing/bulk_indexing.go
@@ -341,7 +341,9 @@ func (processor *BulkIndexingProcessor) HandleQueueConfig(v *queue.QueueConfig, 
 	//TODO, add config to enable/disable singleton, may have performance issue
 	ok, _ := locker.Hold(queueHandleSingleton, v.ID, processor.id, 60*time.Second, true)
 	if !ok {
-		log.Debugf("failed to hold lock for queue:[%v], already hold by somewhere", v.ID)
+		if rate.GetRateLimiter("bulk_queue_lock", v.ID, 1, 1, 30*time.Second).Allow() {
+			log.Debugf("failed to hold lock for queue:[%v], already hold by somewhere", v.ID)
+		}
 		return
 	}
 

--- a/plugins/elastic/bulk_indexing/bulk_indexing.go
+++ b/plugins/elastic/bulk_indexing/bulk_indexing.go
@@ -433,6 +433,10 @@ func (processor *BulkIndexingProcessor) HandleQueueConfig(v *queue.QueueConfig, 
 }
 
 func (processor *BulkIndexingProcessor) NewBulkWorker(parentContext *pipeline.Context, qConfig *queue.QueueConfig, preferedHost string) {
+	if global.Env().IsDebug {
+		// current time for monitoring and log
+		log.Debugf("starting bulk worker for queue: %v, host: %v at time: %v", qConfig.Name, preferedHost, time.Now().Format(time.RFC3339))
+	}
 	bulkSizeInByte := processor.config.BulkConfig.GetBulkSizeInBytes()
 	//check slice
 	for sliceID := 0; sliceID < processor.config.NumOfSlices; sliceID++ {
@@ -460,50 +464,71 @@ func (processor *BulkIndexingProcessor) NewBulkWorker(parentContext *pipeline.Co
 			return
 		}
 
-		processor.Lock()
-		v2, exists := processor.inFlightQueueConfigs.Load(key)
-		if exists {
+		var workerID = util.GetUUID()
+		v2, reserved := processor.reserveInFlightQueue(key, workerID)
+		if !reserved {
 			if global.Env().IsDebug {
 				log.Tracef("[%v], queue [%v], slice_id:%v has more then one consumer, key:%v,v:%v", preferedHost, qConfig.ID, sliceID, key, v2)
 			}
-			processor.Unlock()
 			continue
-		} else {
-			var workerID = util.GetUUID()
-			log.Debugf("starting worker:[%v], queue:[%v], slice_id:%v, host:[%v]", workerID, qConfig.Name, sliceID, preferedHost)
+		}
 
-			ctx1 := &pipeline.Context{}
-			ctx1.Set("key", key)
-			ctx1.Set("workerID", workerID)
-			ctx1.Set("sliceID", sliceID)
-			ctx1.Set("numOfSlices", processor.config.NumOfSlices)
-			ctx1.Set("tag", preferedHost)
-			ctx1.Set("qConfig", qConfig)
-			ctx1.Set("host", preferedHost)
-			ctx1.Set("bulkSizeInByte", bulkSizeInByte)
-			err := processor.pool.Submit(&pipeline.Task{
-				Handler: func(ctx *pipeline.Context, v ...interface{}) {
-					key := ctx.MustGetString("key")
-					workerID := ctx.MustGetString("workerID")
-					host := ctx.MustGetString("host")
-					sliceID := ctx.MustGetInt("sliceID")
-					tag := ctx.MustGetString("tag")
-					numOfSlices := ctx.MustGetInt("numOfSlices")
-					bulkSizeInByte := ctx.MustGetInt("bulkSizeInByte")
-					qConfig := ctx.MustGet("qConfig").(*queue.QueueConfig)
-					pCtx := v[0].(*pipeline.Context)
-					processor.NewSlicedBulkWorker(pCtx, key, workerID, sliceID, numOfSlices, tag, bulkSizeInByte, qConfig, host)
-				},
-				Context: ctx1,
-				Params:  []interface{}{parentContext}, // 也可以在创建任务时设置参数
-			})
-			processor.Unlock()
-			if err != nil {
-				panic(err)
-			}
-			processor.wg.Add(1)
+		log.Debugf("starting worker:[%v], queue:[%v], slice_id:%v, host:[%v]", workerID, qConfig.Name, sliceID, preferedHost)
+
+		ctx1 := &pipeline.Context{}
+		ctx1.Set("key", key)
+		ctx1.Set("workerID", workerID)
+		ctx1.Set("sliceID", sliceID)
+		ctx1.Set("numOfSlices", processor.config.NumOfSlices)
+		ctx1.Set("tag", preferedHost)
+		ctx1.Set("qConfig", qConfig)
+		ctx1.Set("host", preferedHost)
+		ctx1.Set("bulkSizeInByte", bulkSizeInByte)
+		err := processor.pool.Submit(&pipeline.Task{
+			Handler: func(ctx *pipeline.Context, v ...interface{}) {
+				key := ctx.MustGetString("key")
+				workerID := ctx.MustGetString("workerID")
+				host := ctx.MustGetString("host")
+				sliceID := ctx.MustGetInt("sliceID")
+				tag := ctx.MustGetString("tag")
+				numOfSlices := ctx.MustGetInt("numOfSlices")
+				bulkSizeInByte := ctx.MustGetInt("bulkSizeInByte")
+				qConfig := ctx.MustGet("qConfig").(*queue.QueueConfig)
+				pCtx := v[0].(*pipeline.Context)
+				processor.NewSlicedBulkWorker(pCtx, key, workerID, sliceID, numOfSlices, tag, bulkSizeInByte, qConfig, host)
+			},
+			Context: ctx1,
+			Params:  []interface{}{parentContext}, // 也可以在创建任务时设置参数
+		})
+		if err != nil {
+			processor.inFlightQueueConfigs.Delete(key)
+			processor.wg.Done()
+			panic(err)
 		}
 	}
+}
+
+func (processor *BulkIndexingProcessor) reserveInFlightQueue(key, workerID string) (interface{}, bool) {
+	processor.Lock()
+	defer processor.Unlock()
+
+	v, exists := processor.inFlightQueueConfigs.Load(key)
+	if exists {
+		return v, false
+	}
+
+	processor.inFlightQueueConfigs.Store(key, workerID)
+	processor.wg.Add(1)
+
+	return workerID, true
+}
+
+func isIgnorableAcquireConsumerError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return util.ContainStr(err.Error(), "already owning this topic") || util.ContainStr(err.Error(), "the consumer is in fighting list")
 }
 
 var xxHashPool = sync.Pool{
@@ -549,8 +574,6 @@ func (processor *BulkIndexingProcessor) getConsumerConfig(queueID, consumerName 
 }
 
 func (processor *BulkIndexingProcessor) NewSlicedBulkWorker(ctx *pipeline.Context, key, workerID string, sliceID, maxSlices int, tag string, bulkSizeInByte int, qConfig *queue.QueueConfig, host string) {
-	processor.inFlightQueueConfigs.Store(key, workerID)
-
 	defer func() {
 		if !global.Env().IsDebug {
 			if r := recover(); r != nil {
@@ -600,11 +623,14 @@ func (processor *BulkIndexingProcessor) NewSlicedBulkWorker(ctx *pipeline.Contex
 	var consumerInstance queue.ConsumerAPI
 	consumerInstance, err = queue.AcquireConsumer(qConfig, consumerConfig, workerID)
 	if err != nil || consumerInstance == nil {
-		if util.ContainStr(err.Error(), "already owning this topic") {
+		if isIgnorableAcquireConsumerError(err) {
 			if global.Env().IsDebug {
-				log.Warnf("other consumer already owning this topic, queue:%v-%v, slice_id:%v", qConfig.Name, qConfig.ID, sliceID)
+				log.Warnf("skip duplicate consumer acquisition, queue:%v-%v, slice_id:%v, err:%v", qConfig.Name, qConfig.ID, sliceID, err)
 			}
 			return
+		}
+		if err == nil {
+			err = errors.New("failed to acquire queue consumer")
 		}
 		panic(err)
 	}

--- a/plugins/elastic/bulk_indexing/bulk_indexing_test.go
+++ b/plugins/elastic/bulk_indexing/bulk_indexing_test.go
@@ -28,6 +28,7 @@
 package bulk_indexing
 
 import (
+	stdErrors "errors"
 	"github.com/OneOfOne/xxhash"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -83,4 +84,30 @@ func TestXXHash(t *testing.T) {
 		assert.Equal(t, hashValue%3, hash[o])
 	}
 
+}
+
+func TestReserveInFlightQueue(t *testing.T) {
+	processor := &BulkIndexingProcessor{}
+
+	current, reserved := processor.reserveInFlightQueue("queue-0", "worker-1")
+	assert.True(t, reserved)
+	assert.Equal(t, "worker-1", current)
+
+	stored, exists := processor.inFlightQueueConfigs.Load("queue-0")
+	assert.True(t, exists)
+	assert.Equal(t, "worker-1", stored)
+
+	current, reserved = processor.reserveInFlightQueue("queue-0", "worker-2")
+	assert.False(t, reserved)
+	assert.Equal(t, "worker-1", current)
+
+	processor.inFlightQueueConfigs.Delete("queue-0")
+	processor.wg.Done()
+}
+
+func TestIsIgnorableAcquireConsumerError(t *testing.T) {
+	assert.True(t, isIgnorableAcquireConsumerError(stdErrors.New("already owning this topic")))
+	assert.True(t, isIgnorableAcquireConsumerError(stdErrors.New("the consumer is in fighting list")))
+	assert.False(t, isIgnorableAcquireConsumerError(stdErrors.New("some other error")))
+	assert.False(t, isIgnorableAcquireConsumerError(nil))
 }

--- a/plugins/elastic/bulk_indexing/bulk_indexing_test.go
+++ b/plugins/elastic/bulk_indexing/bulk_indexing_test.go
@@ -105,9 +105,21 @@ func TestReserveInFlightQueue(t *testing.T) {
 	processor.wg.Done()
 }
 
+func TestHasInFlightQueue(t *testing.T) {
+	processor := &BulkIndexingProcessor{}
+
+	assert.False(t, processor.hasInFlightQueue("queue-0"))
+
+	processor.inFlightQueueConfigs.Store("queue-0-0", "worker-1")
+	assert.True(t, processor.hasInFlightQueue("queue-0"))
+
+	processor.inFlightQueueConfigs.Delete("queue-0-0")
+	assert.False(t, processor.hasInFlightQueue("queue-0"))
+}
+
 func TestIsIgnorableAcquireConsumerError(t *testing.T) {
 	assert.True(t, isIgnorableAcquireConsumerError(stdErrors.New("already owning this topic")))
-	assert.True(t, isIgnorableAcquireConsumerError(stdErrors.New("the consumer is in fighting list")))
+	assert.False(t, isIgnorableAcquireConsumerError(stdErrors.New("the consumer is in fighting list")))
 	assert.False(t, isIgnorableAcquireConsumerError(stdErrors.New("some other error")))
 	assert.False(t, isIgnorableAcquireConsumerError(nil))
 }


### PR DESCRIPTION
## Summary
- reserve bulk queue workers before submission so duplicate consumers are skipped locally
- keep duplicate-consumer conflicts visible while only rate limiting repeated bulk queue lock logs
- add focused bulk_indexing coverage for in-flight reservation and duplicate-consumer filtering

## Testing
- go test ./plugins/elastic/bulk_indexing
