### PR TITLE
fix(bulk): avoid local queue owner races

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- fix(bulk): avoid local queue owner races between bulk processors (test: `go test ./plugins/elastic/bulk_indexing`) #354
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/plugins/elastic/bulk_indexing/bulk_indexing.go
+++ b/plugins/elastic/bulk_indexing/bulk_indexing.go
@@ -78,6 +78,8 @@ type BulkIndexingProcessor struct {
 	bulkBufferPool *elastic.BulkBufferPool
 }
 
+var queueOwners sync.Map
+
 type Config struct {
 	NumOfSlices          int   `config:"num_of_slices"`
 	Slices               []int `config:"slices"`
@@ -337,9 +339,16 @@ func (processor *BulkIndexingProcessor) Process(c *pipeline.Context) error {
 const queueHandleSingleton = "queue_handler_singleton"
 
 func (processor *BulkIndexingProcessor) HandleQueueConfig(v *queue.QueueConfig, parentContext *pipeline.Context) {
+	if !processor.acquireQueueOwner(v.ID) {
+		if rate.GetRateLimiter("bulk_queue_owner", v.ID, 1, 1, 30*time.Second).Allow() {
+			log.Debugf("skip queue:[%v], already owned by another local bulk processor", v.ID)
+		}
+		return
+	}
+	defer processor.releaseQueueOwnerIfIdle(v.ID)
 
 	//TODO, add config to enable/disable singleton, may have performance issue
-	ok, _ := locker.Hold(queueHandleSingleton, v.ID, processor.id, 60*time.Second, true)
+	ok, _ := locker.Hold(queueHandleSingleton, v.ID, global.Env().SystemConfig.NodeConfig.ID, 60*time.Second, true)
 	if !ok {
 		if rate.GetRateLimiter("bulk_queue_lock", v.ID, 1, 1, 30*time.Second).Allow() {
 			log.Debugf("failed to hold lock for queue:[%v], already hold by somewhere", v.ID)
@@ -544,6 +553,26 @@ func (processor *BulkIndexingProcessor) hasInFlightQueue(queueID string) bool {
 	return hasInFlight
 }
 
+func (processor *BulkIndexingProcessor) acquireQueueOwner(queueID string) bool {
+	owner, loaded := queueOwners.LoadOrStore(queueID, processor.id)
+	if !loaded {
+		return true
+	}
+
+	return owner == processor.id
+}
+
+func (processor *BulkIndexingProcessor) releaseQueueOwnerIfIdle(queueID string) {
+	if processor.hasInFlightQueue(queueID) {
+		return
+	}
+
+	owner, ok := queueOwners.Load(queueID)
+	if ok && owner == processor.id {
+		queueOwners.Delete(queueID)
+	}
+}
+
 func isIgnorableAcquireConsumerError(err error) bool {
 	if err == nil {
 		return false
@@ -615,6 +644,7 @@ func (processor *BulkIndexingProcessor) NewSlicedBulkWorker(ctx *pipeline.Contex
 			}
 		}
 		processor.inFlightQueueConfigs.Delete(key)
+		processor.releaseQueueOwnerIfIdle(qConfig.ID)
 		processor.wg.Done()
 		if global.Env().IsDebug {
 			log.Tracef("exit slice worker, worker:[%v], queue:%v, slice_id:%v, key:%v", workerID, qConfig.ID, sliceID, key)

--- a/plugins/elastic/bulk_indexing/bulk_indexing.go
+++ b/plugins/elastic/bulk_indexing/bulk_indexing.go
@@ -341,7 +341,9 @@ func (processor *BulkIndexingProcessor) HandleQueueConfig(v *queue.QueueConfig, 
 	//TODO, add config to enable/disable singleton, may have performance issue
 	ok, _ := locker.Hold(queueHandleSingleton, v.ID, processor.id, 60*time.Second, true)
 	if !ok {
-		log.Debugf("failed to hold lock for queue:[%v], already hold by somewhere", v.ID)
+		if rate.GetRateLimiter("bulk_queue_lock", v.ID, 1, 1, 30*time.Second).Allow() {
+			log.Debugf("failed to hold lock for queue:[%v], already hold by somewhere", v.ID)
+		}
 		return
 	}
 

--- a/plugins/elastic/bulk_indexing/bulk_indexing_test.go
+++ b/plugins/elastic/bulk_indexing/bulk_indexing_test.go
@@ -31,6 +31,7 @@ import (
 	stdErrors "errors"
 	"github.com/OneOfOne/xxhash"
 	"github.com/stretchr/testify/assert"
+	"sync"
 	"testing"
 )
 
@@ -115,6 +116,36 @@ func TestHasInFlightQueue(t *testing.T) {
 
 	processor.inFlightQueueConfigs.Delete("queue-0-0")
 	assert.False(t, processor.hasInFlightQueue("queue-0"))
+}
+
+func TestAcquireQueueOwner(t *testing.T) {
+	queueOwners = sync.Map{}
+
+	processor1 := &BulkIndexingProcessor{id: "processor-1"}
+	processor2 := &BulkIndexingProcessor{id: "processor-2"}
+
+	assert.True(t, processor1.acquireQueueOwner("queue-0"))
+	assert.True(t, processor1.acquireQueueOwner("queue-0"))
+	assert.False(t, processor2.acquireQueueOwner("queue-0"))
+
+	queueOwners = sync.Map{}
+}
+
+func TestReleaseQueueOwnerIfIdle(t *testing.T) {
+	queueOwners = sync.Map{}
+
+	processor := &BulkIndexingProcessor{id: "processor-1"}
+	assert.True(t, processor.acquireQueueOwner("queue-0"))
+
+	processor.inFlightQueueConfigs.Store("queue-0-0", "worker-1")
+	processor.releaseQueueOwnerIfIdle("queue-0")
+	_, exists := queueOwners.Load("queue-0")
+	assert.True(t, exists)
+
+	processor.inFlightQueueConfigs.Delete("queue-0-0")
+	processor.releaseQueueOwnerIfIdle("queue-0")
+	_, exists = queueOwners.Load("queue-0")
+	assert.False(t, exists)
 }
 
 func TestIsIgnorableAcquireConsumerError(t *testing.T) {


### PR DESCRIPTION
## Summary
- add a local queue ownership guard so only one bulk processor instance claims a queue at a time
- release local ownership when no in-flight queue workers remain for that queue
- add focused bulk_indexing coverage and release notes for the local owner-race fix

## Testing
- go test ./plugins/elastic/bulk_indexing
