### PR TITLE
improve(bulk): include debug summary counters

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- improve(bulk): include summary counters in bulk processor debug exits (test: `go test ./plugins/elastic/bulk_indexing`) #356
 - improve(bulk): stop active queue detection after the processor stays idle (test: `go test ./plugins/elastic/bulk_indexing`) #355
 - fix(bulk): avoid local queue owner races between bulk processors (test: `go test ./plugins/elastic/bulk_indexing`)
 - chore: API Handler Registration Improvements #283

--- a/plugins/elastic/bulk_indexing/bulk_indexing.go
+++ b/plugins/elastic/bulk_indexing/bulk_indexing.go
@@ -235,7 +235,17 @@ func (processor *BulkIndexingProcessor) Process(c *pipeline.Context) error {
 				log.Error("error in bulk indexing processor,", v)
 			}
 		}
-		log.Debug("exit bulk indexing processor")
+		if processor.bulkStats != nil {
+			log.Debugf(
+				"exit bulk indexing processor, success=%d, invalid=%d, failure=%d, error_msgs=%d",
+				processor.bulkStats.Summary.Success.Count,
+				processor.bulkStats.Summary.Invalid.Count,
+				processor.bulkStats.Summary.Failure.Count,
+				len(processor.bulkStats.ErrorMsgs),
+			)
+		} else {
+			log.Debug("exit bulk indexing processor")
+		}
 	}()
 
 	//handle updates
@@ -325,6 +335,15 @@ func (processor *BulkIndexingProcessor) Process(c *pipeline.Context) error {
 						time.Duration(processor.config.DetectIntervalInMs)*time.Millisecond,
 						util.MapLength(&processor.inFlightQueueConfigs),
 					) {
+						if processor.bulkStats != nil {
+							log.Debugf(
+								"active queue detector idle exit, success=%d, invalid=%d, failure=%d, inflight=%d",
+								processor.bulkStats.Summary.Success.Count,
+								processor.bulkStats.Summary.Invalid.Count,
+								processor.bulkStats.Summary.Failure.Count,
+								util.MapLength(&processor.inFlightQueueConfigs),
+							)
+						}
 						return
 					}
 				}


### PR DESCRIPTION
## Summary
- include bulk success, invalid, and failure counters when the bulk processor exits
- include the same counters when active queue detection stops after the processor stays idle
- add release notes and keep focused bulk_indexing test coverage green

## Testing
- go test ./plugins/elastic/bulk_indexing
