### PR TITLE
fix(orm): reject conflicting schema registrations

### DIFF
--- a/core/orm/registry.go
+++ b/core/orm/registry.go
@@ -10,6 +10,11 @@ import (
 
 var registeredSchemas = []util.KeyValue{}
 
+func schemaRegistrationKey(t interface{}) string {
+	pkg, typeName := util.GetTypeAndPackageName(t, true)
+	return pkg + "-" + typeName
+}
+
 func MustRegisterSchemaWithIndexName(t interface{}, index string) {
 	err := RegisterSchemaWithIndexName(t, index)
 	if err != nil {
@@ -18,6 +23,17 @@ func MustRegisterSchemaWithIndexName(t interface{}, index string) {
 }
 
 func RegisterSchemaWithIndexName(t interface{}, index string) error {
+	newKey := schemaRegistrationKey(t)
+	for _, registered := range registeredSchemas {
+		if registered.Key != index {
+			continue
+		}
+		existingKey := schemaRegistrationKey(registered.Payload)
+		if existingKey == newKey {
+			return nil
+		}
+		return errors.Errorf("schema index [%s] already registered by [%s]", index, existingKey)
+	}
 	registeredSchemas = append(registeredSchemas, util.KeyValue{Key: index, Payload: t})
 	return nil
 }

--- a/core/orm/registry_test.go
+++ b/core/orm/registry_test.go
@@ -1,0 +1,39 @@
+package orm
+
+import "testing"
+
+type testSchemaAlpha struct{}
+type testSchemaBeta struct{}
+
+func TestRegisterSchemaWithIndexNameDeduplicatesSameSchema(t *testing.T) {
+	original := registeredSchemas
+	registeredSchemas = nil
+	t.Cleanup(func() {
+		registeredSchemas = original
+	})
+
+	if err := RegisterSchemaWithIndexName(testSchemaAlpha{}, "test-index"); err != nil {
+		t.Fatalf("expected first registration to succeed, got %v", err)
+	}
+	if err := RegisterSchemaWithIndexName(&testSchemaAlpha{}, "test-index"); err != nil {
+		t.Fatalf("expected duplicate registration to be ignored, got %v", err)
+	}
+	if len(registeredSchemas) != 1 {
+		t.Fatalf("expected exactly one registered schema, got %d", len(registeredSchemas))
+	}
+}
+
+func TestRegisterSchemaWithIndexNameRejectsDifferentSchemaForSameIndex(t *testing.T) {
+	original := registeredSchemas
+	registeredSchemas = nil
+	t.Cleanup(func() {
+		registeredSchemas = original
+	})
+
+	if err := RegisterSchemaWithIndexName(testSchemaAlpha{}, "test-index"); err != nil {
+		t.Fatalf("expected first registration to succeed, got %v", err)
+	}
+	if err := RegisterSchemaWithIndexName(testSchemaBeta{}, "test-index"); err == nil {
+		t.Fatal("expected conflicting registration to fail")
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -26,6 +26,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- fix(orm): reject conflicting schema registrations for the same index (test: `go test ./core/orm`) #357
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250


### PR DESCRIPTION
## Summary
- ignore duplicate schema registrations when the same schema type is registered for the same index
- reject conflicting schema types that try to reuse an existing index name
- add focused ORM tests and a release note for the registration guard

## Testing
- go test ./core/orm
