### PR TITLE
fix: shared format target for non-module repositories

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -1,6 +1,7 @@
 name: 'commit-message-check'
 on:
   pull_request:
+    types: [opened, synchronize, reopened, edited]
 
 jobs:
   check-commit-message:

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,10 @@ cross-build-all-platform: clean config build-bsd build-linux build-darwin build-
 
 format:
 	@echo "formatting code"
-	$(GO) fmt $$($(GO) list ./...)
+	find . -type f -name '*.go' \
+		-not -path './vendor/*' \
+		-not -path './.git/*' \
+		-print0 | xargs -0 gofmt -w
 
 test: config
 	$(GOTEST) -v $(GOFLAGS) -timeout 30m ./...

--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ format:
 	find . -type f -name '*.go' \
 		-not -path './vendor/*' \
 		-not -path './.git/*' \
-		-print0 | xargs -0 gofmt -w
+		-exec gofmt -w {} +
 
 test: config
 	$(GOTEST) -v $(GOFLAGS) -timeout 30m ./...


### PR DESCRIPTION
## What does this PR do
- replace `go fmt $(go list ./...)` in the shared `format` target with a direct `gofmt` file walk
- keep the target working for repositories that still build in GOPATH/non-module mode, such as Gateway CI

## Rationale for this change
Gateway PR checks currently fail before running real tests because the shared framework Makefile invokes `go list ./...` under module mode in a non-module repository. This change fixes the shared baseline without changing product logic.

## Standards checklist
- [x] The PR title is descriptive
- [x] The commit messages are semantic
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation
