### PR TITLE
build: support gateway module CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,12 @@ APP_STATIC_PACKAGE ?= public
 APP_UI_FOLDER ?= ui
 APP_PLUGIN_FOLDER ?= plugins
 APP_PLUGIN_PKG ?= $(APP_PLUGIN_FOLDER)
+APP_PLUGIN_EXCLUDE ?=
 APP_NEED_CGO ?= 0
+
+ifeq "$(APP_NAME)" "framework"
+    APP_PLUGIN_EXCLUDE ?= plugins/enterprise
+endif
 
 # Get release version from environment
 ifneq '$(VERSION)' ''
@@ -127,7 +132,7 @@ cross-build-cmd: config
 update-plugins:
 	@if [ ! -e $(OLDGOPATH)/src/infini.sh/framework/bin/plugin-discovery ]; then ( cd $(OLDGOPATH)/src/infini.sh/framework/ && make build-cmd ) fi
 	@$(foreach var,$(APP_PLUGIN_FOLDER),\
-        ( $(OLDGOPATH)/src/infini.sh/framework/bin/plugin-discovery -dir $(var) -pkg $(var) -import_prefix infini.sh/$(APP_NAME) -out $(var)/generated_plugins.go); \
+        ( $(OLDGOPATH)/src/infini.sh/framework/bin/plugin-discovery -dir $(var) $(foreach exclude,$(APP_PLUGIN_EXCLUDE),-exclude $(exclude)) -pkg $(var) -import_prefix infini.sh/$(APP_NAME) -out $(var)/generated_plugins.go); \
     )
 
 # used to build the binary for gdb debugging
@@ -260,7 +265,7 @@ tidy:
 lint: config
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "Installing golangci-lint..."; \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v2.1.6; \
+		GOBIN=$(shell go env GOPATH)/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6; \
 	fi
 	golangci-lint run
 	@$(MAKE) restore-generated-file

--- a/cmd/plugin-discovery/main.go
+++ b/cmd/plugin-discovery/main.go
@@ -50,10 +50,12 @@ var (
 	importPrefix string
 	outFile      string
 	pluginDirs   stringSliceFlag
+	excludeDirs  stringSliceFlag
 )
 
 func init() {
 	flag.Var(&pluginDirs, "dir", "Directory to search for plugins")
+	flag.Var(&excludeDirs, "exclude", "Directory prefix to skip during plugin discovery")
 	flag.StringVar(&importPrefix, "import_prefix", "infini.sh/gateway/", "Prefix for generated package path")
 	flag.StringVar(&pkg, "pkg", "config", "Package name for generated go file")
 	flag.StringVar(&outFile, "out", "config/plugins.go", "Output filename")
@@ -83,11 +85,19 @@ func main() {
 				return nil
 			}
 
+			if shouldExclude(path) {
+				if info != nil && info.IsDir() {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+
 			if err == nil && libRegEx.MatchString(info.Name()) {
 
 				if strings.HasSuffix(info.Name(), "_test.go") {
 					return nil
 				}
+
 				if hasInitMethod(filepath.Join(path)) {
 					imports[filepath.ToSlash(
 						filepath.Join(importPrefix, filepath.Dir(path)))] = util.KV{}
@@ -179,6 +189,17 @@ func hasInitMethod(file string) bool {
 	}
 	if err := scanner.Err(); err != nil {
 		log.Fatalf("Failed scanning %v: %v", file, err)
+	}
+	return false
+}
+
+func shouldExclude(path string) bool {
+	slashed := filepath.ToSlash(path)
+	for _, exclude := range excludeDirs {
+		excluded := filepath.ToSlash(exclude)
+		if slashed == excluded || strings.HasPrefix(slashed, excluded+"/") {
+			return true
+		}
 	}
 	return false
 }

--- a/plugins/generated_plugins.go
+++ b/plugins/generated_plugins.go
@@ -1,0 +1,17 @@
+// GENERATED CODE BY PLUGIN DISCOVERY- DO NOT EDIT.
+
+package plugins
+
+import (
+	_ "infini.sh/framework/plugins/badger"
+	_ "infini.sh/framework/plugins/elastic/indexing_merge"
+	_ "infini.sh/framework/plugins/elastic/json_indexing"
+	_ "infini.sh/framework/plugins/elastic/merge_to_bulk"
+	_ "infini.sh/framework/plugins/replay"
+	_ "infini.sh/framework/plugins/simple_kv"
+	_ "infini.sh/framework/plugins/elastic/bulk_indexing"
+	_ "infini.sh/framework/plugins/http"
+	_ "infini.sh/framework/plugins/queue/consumer"
+	_ "infini.sh/framework/plugins/queue/kafka_queue"
+	_ "infini.sh/framework/plugins/smtp"
+)


### PR DESCRIPTION
## Summary
- exclude enterprise plugins from the default `framework/plugins` aggregate so OSS consumers do not pull `license` transitively
- teach plugin-discovery to skip configured directories and use that for framework plugin generation
- install golangci-lint via `go install` so lint works with modules targeting newer Go versions

## Testing
- `go test ./cmd/plugin-discovery`
- regenerated `plugins/generated_plugins.go` with enterprise plugins excluded
