### PR TITLE
fix: upgrade golangci-lint for go 1.25

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ APP_UI_FOLDER ?= ui
 APP_PLUGIN_FOLDER ?= plugins
 APP_PLUGIN_PKG ?= $(APP_PLUGIN_FOLDER)
 APP_NEED_CGO ?= 0
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 # Get release version from environment
 ifneq '$(VERSION)' ''
@@ -260,7 +261,7 @@ tidy:
 lint: config
 	@if ! command -v golangci-lint >/dev/null 2>&1; then \
 		echo "Installing golangci-lint..."; \
-		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(shell go env GOPATH)/bin v2.1.6; \
+		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); \
 	fi
 	golangci-lint run
 	@$(MAKE) restore-generated-file


### PR DESCRIPTION
## Summary
- add a configurable golangci-lint version in framework Makefile
- upgrade the default lint tool version to v2.12.2
- avoid Go toolchain/version mismatches before linting runs

## Testing
- verified the new golangci-lint release is built with Go 1.26
- reproduced that the old v2.1.6 path fails on newer Go targets before linting starts