### PR TITLE
fix: support gateway CI outside go modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ ifneq "$(DEV)" ""
 endif
 
 GO        := go
+GOMODULE ?= true
+ifneq "$(GOMODULE)" "true"
+    GO := GO15VENDOREXPERIMENT="1" GO111MODULE=off go
+endif
 GOBUILD  := CGO_ENABLED=$(APP_NEED_CGO) $(GO) build -a $(FRAMEWORK_DEVEL_BUILD) -gcflags=all="-l -B"  -ldflags '-static' -ldflags='-s -w' -gcflags "-m"  --work $(GOBUILD_FLAGS)
 GOBUILDDBG  := CGO_ENABLED=$(APP_NEED_CGO) $(GO) build -a $(FRAMEWORK_DEVEL_BUILD) -ldflags -v -gcflags "all=-N -l" --work $(GOBUILD_FLAGS)
 GOBUILDNCGO  := CGO_ENABLED=1 $(GO) build -ldflags -s $(GOBUILD_FLAGS)
@@ -263,7 +267,7 @@ lint: config
 		echo "Installing golangci-lint..."; \
 		curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(shell go env GOPATH)/bin $(GOLANGCI_LINT_VERSION); \
 	fi
-	golangci-lint run
+	$(if $(filter $(GOMODULE),true),golangci-lint run,GO15VENDOREXPERIMENT="1" GO111MODULE=off golangci-lint run)
 	@$(MAKE) restore-generated-file
 
 clean_data:

--- a/lib/guardian/auth/strategies/ldap/ldap.go
+++ b/lib/guardian/auth/strategies/ldap/ldap.go
@@ -25,7 +25,14 @@ type conn interface {
 	Search(searchRequest *ldap.SearchRequest) (*ldap.SearchResult, error)
 	StartTLS(config *tls.Config) error
 	UnauthenticatedBind(username string) error
+}
+
+type connWithCloseError interface {
 	Close() error
+}
+
+type connWithCloseNoError interface {
+	Close()
 }
 
 // Config define the configuration to connect to LDAP.
@@ -80,7 +87,7 @@ func (c client) authenticate(ctx context.Context, r *fasthttp.Request, userName,
 		return nil, err
 	}
 
-	defer l.Close()
+	defer closeConn(l)
 
 	if c.cfg.BindPassword != "" {
 		err = l.Bind(c.cfg.BindDN, c.cfg.BindPassword)
@@ -155,6 +162,16 @@ func (c client) authenticate(ctx context.Context, r *fasthttp.Request, userName,
 	//}
 
 	return auth.NewUserInfo(util.UnsafeBytesToString(userName), id, groups, ext), nil
+}
+
+// closeConn accepts both go-ldap Close signatures used across module and GOPATH builds.
+func closeConn(c conn) {
+	switch v := any(c).(type) {
+	case connWithCloseError:
+		_ = v.Close()
+	case connWithCloseNoError:
+		v.Close()
+	}
 }
 
 // GetAuthenticateFunc return function to authenticate request using LDAP.


### PR DESCRIPTION
Follow-up to #361. Supersedes #362.

This keeps the shared Makefile usable from GOPATH/non-module repositories like gateway by honoring `GOMODULE=false` in `test` and `lint`, and it makes the LDAP strategy tolerate both `go-ldap` Close signatures seen across module and GOPATH builds.

Validation:
- `go test ./lib/guardian/auth/strategies/ldap`
