### PR TITLE
improve(pipeline): include API context in run results

### DIFF
--- a/core/pipeline/context.go
+++ b/core/pipeline/context.go
@@ -299,6 +299,20 @@ func (ctx *Context) Errors() []error {
 	return ctx.processErrs
 }
 
+func (ctx *Context) GetResultState() RunningState {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+
+	return ctx.getResultStateLocked()
+}
+
+func (ctx *Context) GetResultError() string {
+	ctx.stateLock.Lock()
+	defer ctx.stateLock.Unlock()
+
+	return formatPipelineResultError(ctx.exitErr, ctx.processErrs)
+}
+
 // Pause suspends the goroutine that is running this pipeline.
 func (ctx *Context) Pause() {
 	ctx.stateLock.Lock()
@@ -378,6 +392,30 @@ func (ctx *Context) setRunningState(newState RunningState) {
 	}
 }
 
+func (ctx *Context) getResultStateLocked() RunningState {
+	switch ctx.runningState {
+	case FINISHED, FAILED:
+		return ctx.runningState
+	case STOPPED:
+		if ctx.endTime == nil {
+			return STOPPED
+		}
+		if ctx.exitErr != nil || len(ctx.processErrs) > 0 {
+			return FAILED
+		}
+		return FINISHED
+	default:
+		return ""
+	}
+}
+
+func formatPipelineResultError(exitErr error, processErrs []error) string {
+	if exitErr == nil && len(processErrs) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("exit: %v, process: %v", exitErr, processErrs)
+}
+
 func (ctx *Context) pushPipelineLog() {
 	if global.Env().IsDebug {
 		log.Info("received pipeline state change, id: ", ctx.Config.Name, ", state: ", ctx.runningState)
@@ -407,8 +445,8 @@ func (ctx *Context) pushPipelineLog() {
 		result := util.MapStr{
 			"success": ctx.exitErr == nil,
 		}
-		if ctx.exitErr != nil || len(ctx.processErrs) > 0 {
-			result["error"] = fmt.Sprintf("exit: %v, process: %v", ctx.exitErr, ctx.processErrs)
+		if errMsg := formatPipelineResultError(ctx.exitErr, ctx.processErrs); errMsg != "" {
+			result["error"] = errMsg
 		}
 		payload["result"] = result
 	}

--- a/core/pipeline/context_result_test.go
+++ b/core/pipeline/context_result_test.go
@@ -1,0 +1,59 @@
+package pipeline
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestGetResultStateReturnsFinishedAfterStoppedCompletedRun(t *testing.T) {
+	ctx := AcquireContext(PipelineConfigV2{})
+	ctx.Started()
+	ctx.Finished()
+	ctx.Stopped()
+
+	if got := ctx.GetResultState(); got != FINISHED {
+		t.Fatalf("expected FINISHED result state, got %q", got)
+	}
+	if got := ctx.GetResultError(); got != "" {
+		t.Fatalf("expected empty result error, got %q", got)
+	}
+}
+
+func TestGetResultStateReturnsFailedAfterStoppedFailedRun(t *testing.T) {
+	ctx := AcquireContext(PipelineConfigV2{})
+	ctx.Started()
+	ctx.Failed(errors.New("boom"))
+	ctx.Stopped()
+
+	if got := ctx.GetResultState(); got != FAILED {
+		t.Fatalf("expected FAILED result state, got %q", got)
+	}
+	if got := ctx.GetResultError(); got == "" {
+		t.Fatal("expected result error for failed run")
+	}
+}
+
+func TestGetResultStateReturnsStoppedForManualStop(t *testing.T) {
+	ctx := AcquireContext(PipelineConfigV2{})
+	ctx.Started()
+	ctx.Stopping()
+	ctx.Stopped()
+
+	if got := ctx.GetResultState(); got != STOPPED {
+		t.Fatalf("expected STOPPED result state, got %q", got)
+	}
+	if got := ctx.GetResultError(); got != "" {
+		t.Fatalf("expected empty result error, got %q", got)
+	}
+}
+
+func TestGetResultErrorIncludesProcessErrors(t *testing.T) {
+	ctx := AcquireContext(PipelineConfigV2{})
+	ctx.Started()
+	ctx.RecordError(errors.New("slice failed"))
+	ctx.Finished()
+
+	if got := ctx.GetResultError(); got == "" {
+		t.Fatal("expected process error to be surfaced")
+	}
+}

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -30,6 +30,7 @@ Information about release notes of INFINI Framework is provided here.
 
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- improve(pipeline): include API context in pipeline run status results (test: `go test ./core/pipeline ./modules/pipeline/...`) #338
 - chore: API Handler Registration Improvements #283
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250

--- a/modules/pipeline/model.go
+++ b/modules/pipeline/model.go
@@ -31,11 +31,18 @@ import (
 )
 
 type PipelineTaskStatus struct {
-	State      pipeline.RunningState      `json:"state"`
-	CreateTime time.Time                  `json:"create_time"`
-	StartTime  *time.Time                 `json:"start_time"`
-	EndTime    *time.Time                 `json:"end_time"`
-	Context    util.MapStr                `json:"context"`
-	Config     *pipeline.PipelineConfigV2 `json:"config"`
-	Processors []map[string]interface{}   `json:"processor"`
+	State        pipeline.RunningState      `json:"state"`
+	LastRunState pipeline.RunningState      `json:"last_run_state,omitempty"`
+	CreateTime   time.Time                  `json:"create_time"`
+	StartTime    *time.Time                 `json:"start_time"`
+	EndTime      *time.Time                 `json:"end_time"`
+	Context      util.MapStr                `json:"context"`
+	Result       *PipelineResult            `json:"result,omitempty"`
+	Config       *pipeline.PipelineConfigV2 `json:"config"`
+	Processors   []map[string]interface{}   `json:"processor"`
+}
+
+type PipelineResult struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
 }

--- a/modules/pipeline/tasks.go
+++ b/modules/pipeline/tasks.go
@@ -80,11 +80,18 @@ func (module *PipeModule) getPipelineTaskStatus(id string, config string, proces
 		return nil
 	}
 	ret := &PipelineTaskStatus{
-		State:      c1.GetRunningState(),
-		CreateTime: c1.GetCreateTime(),
-		StartTime:  c1.GetStartTime(),
-		EndTime:    c1.GetEndTime(),
-		Context:    c1.CloneData(),
+		State:        c1.GetRunningState(),
+		LastRunState: c1.GetResultState(),
+		CreateTime:   c1.GetCreateTime(),
+		StartTime:    c1.GetStartTime(),
+		EndTime:      c1.GetEndTime(),
+		Context:      c1.CloneData(),
+	}
+	if ret.LastRunState == pipeline.FINISHED || ret.LastRunState == pipeline.FAILED {
+		ret.Result = &PipelineResult{
+			Success: c1.GetResultError() == "",
+			Error:   c1.GetResultError(),
+		}
 	}
 	if config != "false" {
 		v1, ok := module.configs.Load(id)


### PR DESCRIPTION
Supersedes #338.

## Summary
- preserve pipeline context result state and error details for API responses after runs finish or stop
- expose the richer result information through pipeline status handlers
- add focused pipeline tests and release notes for the API context/result behavior

## Testing
- `go test ./core/pipeline ./modules/pipeline/...`
