### PR TITLE
refactor: add priority ordering to HTTPAuthFilterProvider

### DIFF
--- a/core/security/session.go
+++ b/core/security/session.go
@@ -18,7 +18,7 @@ import (
 const UserAccessTokenSessionName = "user_session_access_token"
 
 func init() {
-	RegisterHTTPAuthFilterProvider("session_token", byAccessTokenSession, 10)
+	RegisterHTTPAuthFilterProviderWithPriority("session_token", byAccessTokenSession, 10)
 }
 
 func byAccessTokenSession(w http.ResponseWriter, r *http.Request) (claims *UserClaims, err error) {

--- a/core/security/session.go
+++ b/core/security/session.go
@@ -18,7 +18,7 @@ import (
 const UserAccessTokenSessionName = "user_session_access_token"
 
 func init() {
-	RegisterHTTPAuthFilterProvider("session_token", byAccessTokenSession)
+	RegisterHTTPAuthFilterProvider("session_token", byAccessTokenSession, 10)
 }
 
 func byAccessTokenSession(w http.ResponseWriter, r *http.Request) (claims *UserClaims, err error) {

--- a/core/security/validate.go
+++ b/core/security/validate.go
@@ -6,6 +6,7 @@ package security
 import (
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -67,20 +68,21 @@ func ValidateLogin(w http.ResponseWriter, r *http.Request) (session *UserSession
 
 	var claims *UserClaims
 
-	authHTTPFilterProvider.Range(func(key, value any) bool {
-		log.Trace("checking auth filter: ", key)
-		f, ok := value.(HTTPAuthFilterProvider)
-		if ok {
-			if claims == nil || !claims.UserSessionInfo.IsValid() {
-				claims, err = f(w, r)
-				if claims != nil {
-					log.Debug("get valid auth info from: ", key)
-					return false
-				}
+	authFilterMu.RLock()
+	entries := make([]namedFilterEntry, len(authFilterProviders))
+	copy(entries, authFilterProviders)
+	authFilterMu.RUnlock()
+
+	for _, entry := range entries {
+		log.Trace("checking auth filter: ", entry.name)
+		if claims == nil || !claims.UserSessionInfo.IsValid() {
+			claims, err = entry.fn(w, r)
+			if claims != nil {
+				log.Debug("get valid auth info from: ", entry.name)
+				break
 			}
 		}
-		return true
-	})
+	}
 
 	if claims == nil || !claims.UserSessionInfo.IsValid() || err != nil {
 		err = errors.Errorf("invalid user info: %v", err)
@@ -90,14 +92,34 @@ func ValidateLogin(w http.ResponseWriter, r *http.Request) (session *UserSession
 	return claims.UserSessionInfo, nil
 }
 
-var authHTTPFilterProvider = sync.Map{}
+type namedFilterEntry struct {
+	name     string
+	priority int
+	fn       HTTPAuthFilterProvider
+}
+
+var (
+	authFilterMu        sync.RWMutex
+	authFilterProviders []namedFilterEntry
+)
 
 type HTTPAuthFilterProvider func(w http.ResponseWriter, r *http.Request) (claims *UserClaims, err error)
 
-func RegisterHTTPAuthFilterProvider(name string, f HTTPAuthFilterProvider) {
-	authHTTPFilterProvider.Store(name, f)
+// RegisterHTTPAuthFilterProvider registers an auth filter provider with the given priority.
+// Smaller priority values execute first (higher precedence).
+func RegisterHTTPAuthFilterProvider(name string, f HTTPAuthFilterProvider, priority int) {
+	authFilterMu.Lock()
+	defer authFilterMu.Unlock()
+
+	entry := namedFilterEntry{name: name, priority: priority, fn: f}
+	i := sort.Search(len(authFilterProviders), func(i int) bool {
+		return authFilterProviders[i].priority >= priority
+	})
+	authFilterProviders = append(authFilterProviders, namedFilterEntry{})
+	copy(authFilterProviders[i+1:], authFilterProviders[i:])
+	authFilterProviders[i] = entry
 }
 
 func init() {
-	RegisterHTTPAuthFilterProvider("bearer_token", byAuthorizationHeader)
+	RegisterHTTPAuthFilterProvider("bearer_token", byAuthorizationHeader, 20)
 }

--- a/core/security/validate.go
+++ b/core/security/validate.go
@@ -105,9 +105,9 @@ var (
 
 type HTTPAuthFilterProvider func(w http.ResponseWriter, r *http.Request) (claims *UserClaims, err error)
 
-// RegisterHTTPAuthFilterProvider registers an auth filter provider with the given priority.
+// RegisterHTTPAuthFilterProviderWithPriority registers an auth filter provider with an explicit priority.
 // Smaller priority values execute first (higher precedence).
-func RegisterHTTPAuthFilterProvider(name string, f HTTPAuthFilterProvider, priority int) {
+func RegisterHTTPAuthFilterProviderWithPriority(name string, f HTTPAuthFilterProvider, priority int) {
 	authFilterMu.Lock()
 	defer authFilterMu.Unlock()
 
@@ -120,6 +120,12 @@ func RegisterHTTPAuthFilterProvider(name string, f HTTPAuthFilterProvider, prior
 	authFilterProviders[i] = entry
 }
 
+// RegisterHTTPAuthFilterProvider registers an auth filter provider with the default priority (100).
+// It executes after any provider registered with an explicit priority lower than 100.
+func RegisterHTTPAuthFilterProvider(name string, f HTTPAuthFilterProvider) {
+	RegisterHTTPAuthFilterProviderWithPriority(name, f, 100)
+}
+
 func init() {
-	RegisterHTTPAuthFilterProvider("bearer_token", byAuthorizationHeader, 20)
+	RegisterHTTPAuthFilterProviderWithPriority("bearer_token", byAuthorizationHeader, 20)
 }

--- a/docs/content.en/docs/references/api_web.md
+++ b/docs/content.en/docs/references/api_web.md
@@ -382,11 +382,15 @@ Incoming requests are authenticated through a priority-ordered pipeline of `HTTP
 import "infini.sh/framework/core/security"
 
 func init() {
-    security.RegisterHTTPAuthFilterProvider(
+    // With explicit priority (smaller value = higher precedence)
+    security.RegisterHTTPAuthFilterProviderWithPriority(
         "my_auth",          // unique name (used in logs)
         myAuthProvider,     // func(w http.ResponseWriter, r *http.Request) (*security.UserClaims, error)
-        15,                 // priority — executes after session_token (10) but before bearer_token (20)
+        15,                 // executes after session_token (10) but before bearer_token (20)
     )
+
+    // Without priority — defaults to 100 (executes after all built-in providers)
+    security.RegisterHTTPAuthFilterProvider("my_auth", myAuthProvider)
 }
 
 func myAuthProvider(w http.ResponseWriter, r *http.Request) (*security.UserClaims, error) {

--- a/docs/content.en/docs/references/api_web.md
+++ b/docs/content.en/docs/references/api_web.md
@@ -362,6 +362,41 @@ api.HandleUIMethod(api.GET, "/health", handler.healthCheck,
     api.AllowPublicAccess())
 ```
 
+### Pluggable Auth Filter Pipeline
+
+Incoming requests are authenticated through a priority-ordered pipeline of `HTTPAuthFilterProvider` functions. Each provider attempts to extract and validate credentials from the request; the first one that returns valid claims short-circuits the chain.
+
+#### Built-in Providers
+
+| Priority | Name | Mechanism |
+|----------|------|-----------|
+| `10` | `session_token` | HTTP session / cookie |
+| `20` | `bearer_token` | `Authorization: Bearer <jwt>` header |
+| `30` | `api_token` | `X-API-TOKEN` header |
+
+**Smaller priority values execute first** (higher precedence), consistent with the framework-wide convention.
+
+#### Registering a Custom Provider
+
+```go
+import "infini.sh/framework/core/security"
+
+func init() {
+    security.RegisterHTTPAuthFilterProvider(
+        "my_auth",          // unique name (used in logs)
+        myAuthProvider,     // func(w http.ResponseWriter, r *http.Request) (*security.UserClaims, error)
+        15,                 // priority — executes after session_token (10) but before bearer_token (20)
+    )
+}
+
+func myAuthProvider(w http.ResponseWriter, r *http.Request) (*security.UserClaims, error) {
+    // Extract and validate credentials; return nil claims on failure
+    ...
+}
+```
+
+Providers registered with the same priority value are tried in registration order.
+
 ### Access Token Authentication
 
 The framework provides a built-in access token (API token) module for programmatic authentication. Access tokens allow services and automation tools to authenticate API requests without interactive login sessions.

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ Information about release notes of INFINI Framework is provided here.
 ### ❌ Breaking changes  
 - refactor: native security are disabled by default #283
 - refactor: refactoring to simplify go modules #300
+- refactor: `RegisterHTTPAuthFilterProvider` now requires a `priority int` parameter #370
 
 ### 🚀 Features  
 - feat: support team-based scope for sharing services #258

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,7 +12,6 @@ Information about release notes of INFINI Framework is provided here.
 ### ❌ Breaking changes  
 - refactor: native security are disabled by default #283
 - refactor: refactoring to simplify go modules #300
-- refactor: `RegisterHTTPAuthFilterProvider` now requires a `priority int` parameter #370
 
 ### 🚀 Features  
 - feat: support team-based scope for sharing services #258
@@ -32,6 +31,7 @@ Information about release notes of INFINI Framework is provided here.
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 - chore: API Handler Registration Improvements #283
+- refactor: add priority ordering to HTTP auth filter pipeline; new `RegisterHTTPAuthFilterProviderWithPriority` API #370
 - refactor: use PathUnescape to decode query param filter #249
 - chore: move entity provider to non-managed mode #250
 - chore: always enable orm hooks #250

--- a/modules/security/access_token/authentication.go
+++ b/modules/security/access_token/authentication.go
@@ -63,7 +63,7 @@ func init() {
 	// The auth filter provider is registered unconditionally so that inbound
 	// requests carrying X-API-TOKEN can be authenticated even before Init() is
 	// called (e.g. in embedded scenarios that never call Init explicitly).
-	security.RegisterHTTPAuthFilterProvider("api_token", byAPITokenHeader, 30)
+	security.RegisterHTTPAuthFilterProviderWithPriority("api_token", byAPITokenHeader, 30)
 }
 
 // Init registers the HTTP management endpoints for access tokens. Safe to

--- a/modules/security/access_token/authentication.go
+++ b/modules/security/access_token/authentication.go
@@ -6,10 +6,11 @@ package access_token
 
 import (
 	"fmt"
-	"infini.sh/framework/core/log"
 	"net/http"
 	"sync"
 	"time"
+
+	"infini.sh/framework/core/log"
 
 	"github.com/emirpasic/gods/sets/hashset"
 
@@ -62,7 +63,7 @@ func init() {
 	// The auth filter provider is registered unconditionally so that inbound
 	// requests carrying X-API-TOKEN can be authenticated even before Init() is
 	// called (e.g. in embedded scenarios that never call Init explicitly).
-	security.RegisterHTTPAuthFilterProvider("api_token", byAPITokenHeader)
+	security.RegisterHTTPAuthFilterProvider("api_token", byAPITokenHeader, 30)
 }
 
 // Init registers the HTTP management endpoints for access tokens. Safe to


### PR DESCRIPTION
RegisterHTTPAuthFilterProvider now requires a priority int parameter. Smaller values execute first (higher precedence), consistent with the framework's existing priority convention.

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [x] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation