### PR TITLE
chore: reflect actual permission in profile api

### DIFF
--- a/core/security/cache.go
+++ b/core/security/cache.go
@@ -49,6 +49,7 @@ func GetUserPermissions(shortUser *UserSessionInfo) *UserAssignedPermission {
 	//TODO, handle api key, with specify permissions
 	//TODO, if the provider is for user, like api token, we need to fetch from api token's config, to get the updated permission
 	allowedPermissions := GetAllPermissionsForUser(shortUser)
+	shortUser.Permissions = allowedPermissions
 
 	log.Trace("get user's permissions:", allowedPermissions)
 	perms := NewUserAssignedPermission(allowedPermissions, nil)

--- a/modules/security/account/profile.go
+++ b/modules/security/account/profile.go
@@ -33,7 +33,7 @@ func Profile(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 	p.ID = reqUser.UserID
 
 	//get all permissions for user
-	p.Permissions = security.GetAllPermissionsForUser(reqUser)
+	p.Permissions = reqUser.Permissions
 
 	api.WriteJSON(w, p, http.StatusOK)
 }


### PR DESCRIPTION
## What does this PR do

When access via API Token, the permission maybe subset of the users, and the permission of profile api should be updated to reflect real permissions

## Rationale for this change

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation