### PR TITLE
docs: fix misleading -service-user help text

### DIFF
--- a/app.go
+++ b/app.go
@@ -182,7 +182,7 @@ func (app *App) initWithFlags() {
 	flag.IntVar(&app.numCPU, "cpu", -1, "the number of CPUs to use")
 	flag.IntVar(&app.maxMEM, "mem", -1, "the max size of Memory to use, soft limit in megabyte")
 	flag.StringVar(&app.svcFlag, "service", "", "service management, options: install,uninstall,start,stop")
-	flag.StringVar(&app.svcUser, "service-user", "", "OS user account used when installing the service")
+	flag.StringVar(&app.svcUser, "service-user", "", "OS user account used to run the service")
 
 	if debugFlagInitFunc != nil {
 		debugFlagInitFunc()


### PR DESCRIPTION
The flag description said "used when installing the service", but the value actually sets the OS user the service runs as at runtime, not the user who performs the installation. Corrected to "used to run the service".

## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [ ] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation