### PR TITLE
refactor: add EventSink support to overall utilization collector

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -13,6 +13,7 @@ Information about release notes of INFINI Framework is provided here.
 ### 🚀 Features  
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
+- refactor: add EventSink support to overall utilization collector #387
 
 ## 1.4.2 (2026-06-23)
 ### ❌ Breaking changes  

--- a/modules/metrics/host/overall/overall.go
+++ b/modules/metrics/host/overall/overall.go
@@ -44,6 +44,8 @@ const DefaultBandwidthMbps = 1000
 // Metric collects overall system utilization percentages for CPU, memory, disk, disk I/O and network.
 // Each disk and network interface is monitored independently to identify specific bottlenecks.
 type Metric struct {
+	event.EventSink
+
 	Enabled         bool    `config:"enabled"`
 	IntervalSeconds float64 `config:"interval_seconds"`
 	YellowThreshold float64 `config:"yellow_threshold"`
@@ -99,6 +101,12 @@ type deviceUtilization struct {
 }
 
 func New(cfg *config.Config) (*Metric, error) {
+	return NewWithSink(cfg, event.DefaultEventSink)
+}
+
+// NewWithSink creates a Metric with a custom event sink, allowing callers
+// to redirect events to their own sink instead of the global one.
+func NewWithSink(cfg *config.Config, sink event.EventSink) (*Metric, error) {
 	me := &Metric{
 		Enabled:         true,
 		IntervalSeconds: 10,
@@ -108,6 +116,7 @@ func New(cfg *config.Config) (*Metric, error) {
 		prevNetIO:       make(map[string]*netIOSnapshot),
 		netBandwidth:    make(map[string]float64),
 	}
+	me.EventSink = sink
 
 	err := cfg.Unpack(&me)
 	if err != nil {
@@ -235,7 +244,7 @@ func (m *Metric) Collect() error {
 	fields["status"] = status
 	fields["bottleneck"] = bottleneck
 
-	return event.Save(&event.Event{
+	return m.Save(&event.Event{
 		Metadata: event.EventMetadata{
 			Category: "host",
 			Name:     "overall",


### PR DESCRIPTION
The overall collector used event.Save() directly, which meant callers could not redirect its events to a custom sink — unlike the other four host metric collectors (cpu, memory, disk, network) which all embed event.EventSink and expose a NewWithSink constructor.

Add the EventSink embedded field, a NewWithSink constructor, and switch Collect() from event.Save() to m.Save(). This follows the exact same pattern already established by the other host metric packages, enabling the inspect package to inject its own FileMetricSink.

## Standards checklist

- [x] The PR title is descriptive
- [ ] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation