### PR TITLE
refactor: enable CORS for GET /setting/application

### DIFF
--- a/core/api/setting.go
+++ b/core/api/setting.go
@@ -40,7 +40,7 @@ type AppSettings struct {
 }
 
 func init() {
-	HandleUIMethod(GET, "/setting/application", appSettingsAPIHandler, AllowOPTIONSS(), AllowPublicAccess())
+	HandleUIMethod(GET, "/setting/application", appSettingsAPIHandler, AllowOPTIONSS(), AllowPublicAccess(), Feature(FeatureCORS))
 	HandleAPIMethod(GET, "/setting/application", appSettingsAPIHandler)
 }
 

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -14,6 +14,7 @@ Information about release notes of INFINI Framework is provided here.
 ### 🐛 Bug fix  
 ### ✈️ Improvements  
 - refactor: add EventSink support to overall utilization collector #387
+- refactor: enable CORS for GET /setting/application #390
 
 ## 1.4.2 (2026-06-23)
 ### ❌ Breaking changes  


### PR DESCRIPTION
The Easysearch UI needs to call /setting/application on the Agent to discover the agent/provider configuration and to link an Easysearch node back to its managing agent. Without CORS headers, browsers block these cross-origin requests when the UI is served from a different host/port.

Add the CORS feature flag to the GET /setting/application endpoint so the agent can respond with the appropriate Access-Control-Allow-Origin and allowed headers.


## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation