### PR TITLE
fix: expand configs.template when loading templated config files

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -249,7 +249,14 @@ func LoadFile(path string) (*Config, error) {
 			Path:     path,
 			Variable: envObj,
 		}
-		return NewConfigWithTemplate(tempConfig)
+		cfg, err := NewConfigWithTemplate(tempConfig)
+		if err != nil {
+			return nil, err
+		}
+		// The render path above only substitutes variables in the main file;
+		// configs referenced via `configs.template` still need to be inlined,
+		// same as the plain-file path in internalLoadFile.
+		return expandConfigTemplates(cfg)
 	}
 	return internalLoadFile(path)
 }
@@ -320,6 +327,20 @@ func internalLoadFile(path string) (*Config, error) {
 
 	pCfg := fromConfig(c)
 
+	pCfg, err = expandConfigTemplates(pCfg)
+	if err != nil {
+		return pCfg, err
+	}
+
+	log.Debugf("load config file '%v'", path)
+	return pCfg, err
+}
+
+// Helper function to inline every config referenced by the `configs.template`
+// section into the given config. Templates are rendered with their own
+// `variable` map and merged back, so the returned config contains the
+// expanded sections (e.g. entry, flow) alongside the template references.
+func expandConfigTemplates(pCfg *Config) (*Config, error) {
 	if pCfg.HasField("configs") {
 		templates := TemplateConfigs{}
 		pCfg.Unpack(&templates)
@@ -344,9 +365,7 @@ func internalLoadFile(path string) (*Config, error) {
 		}
 
 	}
-
-	log.Debugf("load config file '%v'", path)
-	return pCfg, err
+	return pCfg, nil
 }
 
 func NestedRenderingTemplate(temp string, runKv util.MapStr) string {

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -24,6 +24,8 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/magiconair/properties/assert"
@@ -868,4 +870,104 @@ func TestWildcardPathFilter(t *testing.T) {
 		})
 	}
 
+}
+
+type templateEntryConfig struct {
+	Name    string `config:"name"`
+	Enabled bool   `config:"enabled"`
+	Network struct {
+		Binding string `config:"binding"`
+	} `config:"network"`
+}
+
+func writeTemplateConfigFiles(t *testing.T, mainTpl string, tplContent string) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	mainPath := filepath.Join(dir, "gateway.yml")
+	tplPath := filepath.Join(dir, "config_template.tpl")
+	if err := os.WriteFile(mainPath, []byte(mainTpl), 0644); err != nil {
+		t.Fatalf("failed to write main config: %v", err)
+	}
+	if err := os.WriteFile(tplPath, []byte(tplContent), 0644); err != nil {
+		t.Fatalf("failed to write template: %v", err)
+	}
+	return dir, mainPath
+}
+
+// A config containing $[[ placeholders takes the rendering path of LoadFile;
+// sections referenced via configs.template must still be inlined.
+func TestLoadFileExpandsConfigTemplates(t *testing.T) {
+	const mainConfig = `env:
+  BINDING_HOST: 127.0.0.1:8001
+
+configs.template:
+  - name: "test_entry"
+    path: ./config_template.tpl
+    variable:
+      name: "test_entry"
+      binding_host: $[[env.BINDING_HOST]]
+`
+	const tpl = `entry:
+  - name: my_entry_$[[name]]
+    enabled: true
+    network:
+      binding: $[[binding_host]]
+`
+	dir, mainPath := writeTemplateConfigFiles(t, mainConfig, tpl)
+	t.Chdir(dir)
+
+	cfg, err := LoadFile(mainPath)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	out := struct {
+		Entry []templateEntryConfig `config:"entry"`
+	}{}
+	if err := cfg.Unpack(&out); err != nil {
+		t.Fatalf("failed to unpack config: %v", err)
+	}
+	if len(out.Entry) != 1 {
+		t.Fatalf("expected 1 entry from config template, got %d", len(out.Entry))
+	}
+	assert.Equal(t, out.Entry[0].Name, "my_entry_test_entry")
+	assert.Equal(t, out.Entry[0].Enabled, true)
+	assert.Equal(t, out.Entry[0].Network.Binding, "127.0.0.1:8001")
+}
+
+// A config without any placeholder goes through internalLoadFile, which
+// inlines configs.template as before; guard against regressions.
+func TestLoadFileExpandsConfigTemplatesPlain(t *testing.T) {
+	const mainConfig = `configs.template:
+  - name: "test_entry"
+    path: ./config_template.tpl
+    variable:
+      name: "test_entry"
+      binding_host: 127.0.0.1:8002
+`
+	const tpl = `entry:
+  - name: my_entry_$[[name]]
+    enabled: true
+    network:
+      binding: $[[binding_host]]
+`
+	dir, mainPath := writeTemplateConfigFiles(t, mainConfig, tpl)
+	t.Chdir(dir)
+
+	cfg, err := LoadFile(mainPath)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	out := struct {
+		Entry []templateEntryConfig `config:"entry"`
+	}{}
+	if err := cfg.Unpack(&out); err != nil {
+		t.Fatalf("failed to unpack config: %v", err)
+	}
+	if len(out.Entry) != 1 {
+		t.Fatalf("expected 1 entry from config template, got %d", len(out.Entry))
+	}
+	assert.Equal(t, out.Entry[0].Name, "my_entry_test_entry")
+	assert.Equal(t, out.Entry[0].Network.Binding, "127.0.0.1:8002")
 }

--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -12,6 +12,7 @@ Information about release notes of INFINI Framework is provided here.
 ### ❌ Breaking changes  
 ### 🚀 Features  
 ### 🐛 Bug fix  
+- fix: expand configs.template when loading templated config files #391
 ### ✈️ Improvements  
 - refactor: add EventSink support to overall utilization collector #387
 - refactor: enable CORS for GET /setting/application #390


### PR DESCRIPTION
When a config file contains any $[[ placeholder, LoadFile takes the
rendering path: it substitutes variables in the main file and returns
the result without inlining the sections referenced via
configs.template. The template expansion inside internalLoadFile only
runs as a side effect of variable extraction and its merged result is
discarded, so any section contributed by a referenced template is
silently missing from the final config.

For example, with a config like:

    env:
      LR_GATEWAY_HOST: 127.0.0.1:8001

    configs.template:
      - name: "es_gw1"
        path: ./config_template.tpl
        variable:
          name: "es_gw1"
          binding_host: $[[env.LR_GATEWAY_HOST]]

and config_template.tpl:

    entry:
      - name: my_es_entry_$[[name]]
        enabled: true
        network:
          binding: $[[binding_host]]

the entry section never reaches the application, so the listener it
declares never starts.

The template expansion logic is now shared between both loading paths:
internalLoadFile keeps its existing behavior, and the rendering path
expands configs.template after variable substitution, at which point
the template variables have already been resolved to concrete values.


## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [x] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation