### PR TITLE
refactor: rate limit the large cluster warning in metric collection

### DIFF
--- a/docs/content.en/docs/release-notes/_index.md
+++ b/docs/content.en/docs/release-notes/_index.md
@@ -27,6 +27,7 @@ Information about release notes of INFINI Framework is provided here.
 ### ✈️ Improvements  
 - refactor: add EventSink support to overall utilization collector #387
 - refactor: enable CORS for GET /setting/application #390
+- refactor: rate limit the large cluster warning in metric collection #394
 
 ## 1.4.2 (2026-06-23)
 ### ❌ Breaking changes  

--- a/modules/metrics/elastic/elasticsearch.go
+++ b/modules/metrics/elastic/elasticsearch.go
@@ -32,6 +32,7 @@ import (
 	"infini.sh/framework/core/elastic"
 	"infini.sh/framework/core/event"
 	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/rate"
 	"infini.sh/framework/core/task"
 	"infini.sh/framework/core/util"
 	"sync"
@@ -57,6 +58,19 @@ type ElasticsearchMetric struct {
 	Interval     string `config:"interval"`
 	onSaveEvent  func(item *event.Event) error
 	taskIDs      sync.Map
+}
+
+// largeClusterWarnInterval is the minimum time between repeated "large
+// cluster" warnings for the same cluster, so the message is not logged at
+// the same frequency as the metric collection tasks.
+const largeClusterWarnInterval = 10 * time.Minute
+
+// Helper function to report whether the "large cluster" warning may be
+// logged for the given cluster, at most once per largeClusterWarnInterval.
+// The caller is responsible for the actual log call so that the logged
+// source location points to the call site instead of this helper.
+func allowLargeClusterWarn(clusterID string) bool {
+	return rate.GetRateLimiter("large_cluster_warn", clusterID, 1, 1, largeClusterWarnInterval).Allow()
 }
 
 //元数据定期快照
@@ -297,7 +311,9 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 					indexInfos[item.NodeID][item.Index] = true
 				}
 				if len(shardInfos) > 50 || len(shards) > 5000 {
-					log.Warnf("cluster [%v] has over 50 nodes or 5000 shards. use the agent for metrics collection: https://github.com/infinilabs/agent.", v.Config.Name)
+					if allowLargeClusterWarn(k) {
+						log.Warnf("cluster [%v] has over 50 nodes or 5000 shards. use the agent for metrics collection: https://github.com/infinilabs/agent.", v.Config.Name)
+					}
 				}
 
 				host := v.GetActiveHost()
@@ -349,7 +365,9 @@ func (m *ElasticsearchMetric) InitialCollectTask(k string, v *elastic.Elasticsea
 					//return true
 				}
 				if (v.Health != nil && v.Health.NumberOfNodes > 50) || len(shards) > 5000 {
-					log.Warnf("cluster [%v] has over 50 nodes or 5000 shards. use the agent for metrics collection: https://github.com/infinilabs/agent.", v.Config.Name)
+					if allowLargeClusterWarn(k) {
+						log.Warnf("cluster [%v] has over 50 nodes or 5000 shards. use the agent for metrics collection: https://github.com/infinilabs/agent.", v.Config.Name)
+					}
 				}
 				indexStats, err := client.GetStats()
 				if err != nil {


### PR DESCRIPTION
For clusters with over 50 nodes or 5000 shards, the node stats and index stats collection tasks logged a warning on every collection interval, so the message repeated as frequently as the tasks ran (every 10s by default).

The warning is now emitted through a helper that keeps per-cluster state guarded by its own lock and logs at most once every 10 minutes per cluster. The state entry is also dropped when the cluster's collect tasks are removed, so it does not linger after the cluster is deleted.


## Standards checklist

- [x] The PR title is descriptive
- [x] The commit messages are [semantic](https://www.conventionalcommits.org/)
- [ ] Necessary tests are added
- [x] Updated the release notes
- [ ] Necessary documents have been added if this is a new feature
- [ ] Performance tests checked, no obvious performance degradation