### PR TITLE
feat(api): add Cache option and ResponseCacheFilter

### DIFF
--- a/core/api/options.go
+++ b/core/api/options.go
@@ -24,6 +24,8 @@
 package api
 
 import (
+	"time"
+
 	"infini.sh/framework/core/util"
 )
 
@@ -53,6 +55,10 @@ type HandlerOptions struct {
 	Labels            util.MapStr
 	Features          map[string]bool
 	Tags              []string
+	// CacheTTL, when > 0, enables short-TTL caching of successful GET
+	// responses for this route via the ResponseCacheFilter. Intended for
+	// read-only, slowly-changing aggregates that are polled frequently.
+	CacheTTL time.Duration
 	// Add other options as needed
 }
 
@@ -171,6 +177,18 @@ func Feature(feature string) Option {
 
 func MCPAuto() Option {
 	return Feature(FeatureMCPAuto)
+}
+
+// Cache enables short-TTL response caching for a GET route. The
+// ResponseCacheFilter serves subsequent requests within ttl directly from
+// cache, skipping the handler entirely. The cache is keyed by URL plus the
+// authenticated caller and the request body, so responses are not mixed across
+// users or bodies. Use for read-only, idempotent endpoints whose data changes
+// slowly relative to the polling rate.
+func Cache(ttl time.Duration) Option {
+	return func(o *HandlerOptions) {
+		o.CacheTTL = ttl
+	}
 }
 
 func MCPTool(name, description string) Option {

--- a/core/config/system.go
+++ b/core/config/system.go
@@ -415,6 +415,7 @@ type WebAppConfig struct {
 	EmbeddingAPI bool              `config:"embedding_api"`
 	MCP          MCPConfig         `config:"mcp"`
 	Gzip         GzipConfig        `config:"gzip"`
+	ResponseCache ResponseCacheConfig `config:"response_cache"`
 	S3Config     S3BucketConfig    `config:"s3"`
 
 	Cookie CookieConfig `config:"cookie"`
@@ -535,6 +536,15 @@ type AutoIssue struct {
 type GzipConfig struct {
 	Enabled bool `config:"enabled"`
 	Level   int  `config:"level"`
+}
+
+// ResponseCacheConfig controls the opt-in GET response cache (api.Cache).
+// The cache is disabled by default: even routes that set api.Cache pass
+// through uncached unless Enabled is true. This keeps caching a deliberate,
+// global opt-in for the few high-frequency, slowly-changing endpoints that
+// warrant it.
+type ResponseCacheConfig struct {
+	Enabled bool `config:"enabled"`
 }
 
 type WebsocketConfig struct {

--- a/modules/security/http_filters/response_cache.go
+++ b/modules/security/http_filters/response_cache.go
@@ -1,0 +1,196 @@
+/* Copyright © INFINI LTD. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+package http_filters
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"strconv"
+
+	"infini.sh/framework/core/api"
+	httprouter "infini.sh/framework/core/api/router"
+	"infini.sh/framework/core/global"
+	"infini.sh/framework/core/security"
+	"infini.sh/framework/core/util"
+	ccache "infini.sh/framework/lib/cache"
+)
+
+// maxCacheableBodyBytes caps the response size eligible for caching, so an
+// opt-in route that happens to return a large payload cannot balloon memory.
+const maxCacheableBodyBytes = 1 << 20 // 1 MiB
+
+// maxRequestBodyHashBytes caps how much of a GET request body is read to mix
+// into the cache key (GET-with-body is legal and can affect the response). A
+// request body larger than this is served but not cached, since keying it
+// reliably would mean buffering it all in memory.
+const maxRequestBodyHashBytes = 1 << 20 // 1 MiB
+
+// responseCache holds serialized GET response bodies for routes opted into
+// caching via the api.Cache option. It uses the framework's standard ccache
+// (LRU + TTL + size bound).
+var responseCache = ccache.New(ccache.Configure().MaxSize(5000))
+
+// isEnabled reports whether the opt-in response cache is turned on globally
+// (web.response_cache.enabled). Read per-request so a config reload takes
+// effect without restart. Off by default — caching only happens on routes that
+// both set api.Cache and run with this flag enabled. Overridable in tests.
+var isEnabled = func() bool {
+	return global.Env().SystemConfig.WebAppConfig.ResponseCache.Enabled
+}
+
+// InvalidateAll purges every cached GET response. Call it when any data that
+// feeds a cached route has changed and you want a blanket reset.
+func InvalidateAll() {
+	responseCache.Clear()
+}
+
+// InvalidatePath purges cached responses for a specific method + path (across
+// all query strings, callers, and request bodies) and returns how many entries
+// it removed. Call it when the data behind a particular cached route changed,
+// e.g. after creating/deleting the resource that route lists.
+func InvalidatePath(method, path string) int {
+	return responseCache.DeletePrefix(method + ":" + path + "?")
+}
+
+// cachedResponse is what we store: the body bytes plus the Content-Type the
+// handler set, so a cache hit can replay an identical response.
+type cachedResponse struct {
+	body        []byte
+	contentType string
+}
+
+// ResponseCacheFilter serves cached GET responses for routes whose options set
+// CacheTTL > 0 (via api.Cache) — and only when the web.response_cache.enabled
+// feature flag is on (default off). On a miss it runs the handler, then caches
+// successful (200) responses. It only applies to GET.
+//
+// Cache key: keyed by method + URL + the authenticated caller's user id + a
+// hash of the request body. Including the caller prevents one user's response
+// being served to another ("串用户"); the auth filter (priority 200) has already
+// resolved the caller from Authorization/Cookie/X-API-TOKEN into the request
+// context before this filter (priority 1500) runs. Hashing the body makes
+// GET-with-body safe (the body is read, hashed, and restored for the handler).
+//
+// Priority 1500 makes it the innermost filter: auth (200), permission (500)
+// and JSON masking (1000) all run first, so a cached body is only ever served
+// to authorized callers and after masking is applied.
+type ResponseCacheFilter struct{}
+
+func init() {
+	api.RegisterUIFilter(&ResponseCacheFilter{})
+}
+
+func (f *ResponseCacheFilter) GetPriority() int {
+	// Lower values execute first.
+	return 1500
+}
+
+func (f *ResponseCacheFilter) ApplyFilter(
+	method string,
+	pattern string,
+	options *api.HandlerOptions,
+	next httprouter.Handle,
+) httprouter.Handle {
+	if options == nil || options.CacheTTL <= 0 || method != string(api.GET) {
+		return next
+	}
+	ttl := options.CacheTTL
+
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		// Master feature flag (web.response_cache.enabled). Off by default;
+		// when off, opted-in routes simply run the handler uncached.
+		if !isEnabled() {
+			next(w, r, ps)
+			return
+		}
+
+		key, cacheable := cacheKeyFor(r)
+
+		// Cache hit: replay the stored response verbatim.
+		if cacheable {
+			if item := responseCache.Get(key); item != nil && !item.Expired() {
+				if cr, ok := item.Value().(*cachedResponse); ok {
+					if cr.contentType != "" {
+						w.Header().Set("Content-Type", cr.contentType)
+					}
+					w.Header().Set("X-API-Cache", "HIT")
+					_, _ = w.Write(cr.body)
+					return
+				}
+			}
+		}
+
+		// Miss: run the handler through a pass-through writer that also
+		// buffers the body for caching.
+		rec := &cacheResponseWriter{ResponseWriter: w}
+		next(rec, r, ps)
+
+		if !cacheable || rec.buf.Len() == 0 || rec.buf.Len() > maxCacheableBodyBytes {
+			return
+		}
+		// Cache only successful, bounded responses. statusCode 0 means
+		// WriteHeader was never called, i.e. the handler wrote a 200 body.
+		if rec.statusCode == 0 || rec.statusCode == http.StatusOK {
+			responseCache.Set(key, &cachedResponse{
+				body:        rec.buf.Bytes(),
+				contentType: rec.Header().Get("Content-Type"),
+			}, ttl)
+		}
+	}
+}
+
+// cacheKeyFor builds the cache key from the URL, the authenticated caller, and
+// the request body. It returns cacheable=false when the request body is too
+// large to key reliably — in that case the caller should serve without caching
+// rather than risk a truncated-hash collision. The request body is consumed
+// and restored so the downstream handler still sees it.
+func cacheKeyFor(r *http.Request) (key string, cacheable bool) {
+	key = r.Method + ":" + r.URL.Path + "?" + r.URL.RawQuery + "|u=" + callerUserID(r)
+
+	if r.Body == nil || r.ContentLength == 0 {
+		return key, true
+	}
+	// GET-with-body: mix a hash of the body into the key. Limit the read so a
+	// huge body can't be forced into memory; if it exceeds the cap, skip
+	// caching rather than keying on a truncated hash.
+	buf, err := io.ReadAll(io.LimitReader(r.Body, maxRequestBodyHashBytes+1))
+	_ = r.Body.Close()
+	r.Body = io.NopCloser(bytes.NewReader(buf))
+	if err != nil || len(buf) > maxRequestBodyHashBytes {
+		return key, false
+	}
+	if len(buf) > 0 {
+		key += "|b=" + strconv.FormatUint(uint64(util.XXHash(string(buf))), 16)
+	}
+	return key, true
+}
+
+// callerUserID returns the authenticated caller's user id from the request
+// context, or "" when the request is unauthenticated (e.g. public routes).
+func callerUserID(r *http.Request) string {
+	if u, err := security.GetUserFromContext(r.Context()); err == nil && u != nil {
+		return u.UserID
+	}
+	return ""
+}
+
+// cacheResponseWriter is a pass-through http.ResponseWriter that also buffers
+// the response body so it can be cached after the handler returns. Writes still
+// reach the client immediately; the buffer is best-effort.
+type cacheResponseWriter struct {
+	http.ResponseWriter
+	statusCode int
+	buf        bytes.Buffer
+}
+
+func (c *cacheResponseWriter) WriteHeader(code int) {
+	c.statusCode = code
+	c.ResponseWriter.WriteHeader(code)
+}
+
+func (c *cacheResponseWriter) Write(b []byte) (int, error) {
+	c.buf.Write(b) // best-effort capture; bytes.Buffer.Write never errors
+	return c.ResponseWriter.Write(b)
+}

--- a/modules/security/http_filters/response_cache_test.go
+++ b/modules/security/http_filters/response_cache_test.go
@@ -1,0 +1,260 @@
+/* Copyright © INFINI LTD. All rights reserved.
+ * Web: https://infinilabs.com
+ * Email: hello#infini.ltd */
+package http_filters
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"infini.sh/framework/core/api"
+	httprouter "infini.sh/framework/core/api/router"
+	"infini.sh/framework/core/security"
+)
+
+// withCacheEnabled forces the response-cache feature flag on for a test and
+// restores the previous value on cleanup, and starts from an empty cache so
+// tests don't depend on global env or on each other.
+func withCacheEnabled(t *testing.T) {
+	t.Helper()
+	prev := isEnabled
+	isEnabled = func() bool { return true }
+	t.Cleanup(func() { isEnabled = prev })
+	responseCache.Clear()
+}
+
+func TestResponseCacheFilter_HitSkipsHandler(t *testing.T) {
+	withCacheEnabled(t)
+	filter := &ResponseCacheFilter{}
+	opts := &api.HandlerOptions{CacheTTL: 30 * time.Second}
+
+	calls := 0
+	next := func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		calls++
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}
+	wrapped := filter.ApplyFilter(string(api.GET), "/x", opts, next)
+
+	// 1st request: cache miss → handler runs, body returned, no HIT header.
+	rec1 := httptest.NewRecorder()
+	wrapped(rec1, httptest.NewRequest(http.MethodGet, "/x?r=1", nil), nil)
+	if calls != 1 {
+		t.Fatalf("miss: expected handler called once, got %d", calls)
+	}
+	if rec1.Body.String() != `{"ok":true}` {
+		t.Fatalf("miss body = %q", rec1.Body.String())
+	}
+	if rec1.Header().Get("X-API-Cache") == "HIT" {
+		t.Fatal("miss should not be marked HIT")
+	}
+
+	// 2nd request (same URL): cache hit → handler NOT called, body + type replayed.
+	rec2 := httptest.NewRecorder()
+	wrapped(rec2, httptest.NewRequest(http.MethodGet, "/x?r=1", nil), nil)
+	if calls != 1 {
+		t.Fatalf("hit: expected handler skipped, got calls=%d", calls)
+	}
+	if rec2.Body.String() != `{"ok":true}` {
+		t.Fatalf("hit body = %q", rec2.Body.String())
+	}
+	if rec2.Header().Get("X-API-Cache") != "HIT" {
+		t.Fatal("hit should be marked HIT")
+	}
+	if ct := rec2.Header().Get("Content-Type"); ct != "application/json" {
+		t.Fatalf("content-type not replayed: %q", ct)
+	}
+
+	// 3rd request (different query): different key → miss again.
+	rec3 := httptest.NewRecorder()
+	wrapped(rec3, httptest.NewRequest(http.MethodGet, "/x?r=2", nil), nil)
+	if calls != 2 {
+		t.Fatalf("different query: expected handler called, got calls=%d", calls)
+	}
+}
+
+func TestResponseCacheFilter_BypassedWithoutOptionOrForNonGET(t *testing.T) {
+	filter := &ResponseCacheFilter{}
+
+	// No CacheTTL → next returned unchanged.
+	if h := filter.ApplyFilter(string(api.GET), "/x", &api.HandlerOptions{}, nil); h != nil {
+		t.Fatal("expected next unchanged when CacheTTL==0")
+	}
+	// Non-GET → next returned unchanged even with CacheTTL set.
+	opts := &api.HandlerOptions{CacheTTL: time.Second}
+	if h := filter.ApplyFilter(string(api.POST), "/x", opts, nil); h != nil {
+		t.Fatal("expected next unchanged for non-GET")
+	}
+}
+
+func TestResponseCacheFilter_NonOKNotCached(t *testing.T) {
+	withCacheEnabled(t)
+	filter := &ResponseCacheFilter{}
+	opts := &api.HandlerOptions{CacheTTL: 30 * time.Second}
+
+	calls := 0
+	next := func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		calls++
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`err`))
+	}
+	wrapped := filter.ApplyFilter(string(api.GET), "/err", opts, next)
+
+	for i := 0; i < 2; i++ {
+		wrapped(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/err", nil), nil)
+	}
+	if calls != 2 {
+		t.Fatalf("non-200 must not be cached; expected handler called twice, got %d", calls)
+	}
+}
+
+// TestResponseCacheFilter_BodyAffectsKey ensures GET-with-body requests key the
+// body into the cache, so two different bodies to the same URL are not confused.
+// It also verifies the body is still readable by the downstream handler.
+func TestResponseCacheFilter_BodyAffectsKey(t *testing.T) {
+	withCacheEnabled(t)
+	filter := &ResponseCacheFilter{}
+	opts := &api.HandlerOptions{CacheTTL: 30 * time.Second}
+
+	calls := 0
+	lastBody := ""
+	next := func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		calls++
+		b, _ := io.ReadAll(r.Body)
+		lastBody = string(b)
+		_, _ = w.Write([]byte("ok"))
+	}
+	wrapped := filter.ApplyFilter(string(api.GET), "/x", opts, next)
+
+	do := func(body string) {
+		wrapped(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/x", strings.NewReader(body)), nil)
+	}
+	do("aaa") // miss
+	do("aaa") // same body → hit
+	do("bbb") // different body → miss
+	if calls != 2 {
+		t.Fatalf("body should affect key: expected handler called twice (miss,hit,miss), got %d", calls)
+	}
+	if lastBody != "bbb" {
+		t.Fatalf("handler should see the restored body; last body = %q", lastBody)
+	}
+}
+
+// TestResponseCacheFilter_CallerAffectsKey ensures the authenticated caller is
+// part of the key, so one user's cached response is never served to another.
+func TestResponseCacheFilter_CallerAffectsKey(t *testing.T) {
+	withCacheEnabled(t)
+	filter := &ResponseCacheFilter{}
+	opts := &api.HandlerOptions{CacheTTL: 30 * time.Second}
+
+	calls := 0
+	next := func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		calls++
+		_, _ = w.Write([]byte("ok"))
+	}
+	wrapped := filter.ApplyFilter(string(api.GET), "/x", opts, next)
+
+	doAs := func(userID string) {
+		u := &security.UserSessionInfo{}
+		u.SetUserID(userID)
+		req := httptest.NewRequest(http.MethodGet, "/x", nil).
+			WithContext(security.AddUserToContext(context.Background(), u))
+		wrapped(httptest.NewRecorder(), req, nil)
+	}
+	doAs("alice") // miss
+	doAs("alice") // same caller → hit
+	doAs("bob")   // different caller → miss (no cross-user leak)
+	if calls != 2 {
+		t.Fatalf("caller should affect key: expected handler called twice, got %d", calls)
+	}
+}
+
+// TestResponseCacheFilter_DisabledByFlag verifies the feature flag gates the
+// whole cache: with it off, even an opted-in route runs the handler every time.
+func TestResponseCacheFilter_DisabledByFlag(t *testing.T) {
+	filter := &ResponseCacheFilter{}
+	opts := &api.HandlerOptions{CacheTTL: 30 * time.Second}
+
+	prev := isEnabled
+	isEnabled = func() bool { return false }
+	t.Cleanup(func() { isEnabled = prev })
+
+	calls := 0
+	next := func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		calls++
+		_, _ = w.Write([]byte("ok"))
+	}
+	wrapped := filter.ApplyFilter(string(api.GET), "/x", opts, next)
+	for i := 0; i < 3; i++ {
+		wrapped(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/x", nil), nil)
+	}
+	if calls != 3 {
+		t.Fatalf("with flag disabled, every request must hit the handler; got %d", calls)
+	}
+}
+
+// TestResponseCacheFilter_InvalidateAll verifies an active full purge.
+func TestResponseCacheFilter_InvalidateAll(t *testing.T) {
+	withCacheEnabled(t)
+	filter := &ResponseCacheFilter{}
+	opts := &api.HandlerOptions{CacheTTL: time.Minute}
+
+	calls := 0
+	next := func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		calls++
+		_, _ = w.Write([]byte("ok"))
+	}
+	wrapped := filter.ApplyFilter(string(api.GET), "/x", opts, next)
+
+	wrapped(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/x", nil), nil) // miss
+	wrapped(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/x", nil), nil) // hit
+	if calls != 1 {
+		t.Fatalf("expected 1 call before purge, got %d", calls)
+	}
+
+	InvalidateAll()
+	wrapped(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/x", nil), nil) // miss again
+	if calls != 2 {
+		t.Fatalf("expected 2 calls after InvalidateAll, got %d", calls)
+	}
+}
+
+// TestResponseCacheFilter_InvalidatePath verifies a scoped purge by method+path
+// leaves other cached paths untouched.
+func TestResponseCacheFilter_InvalidatePath(t *testing.T) {
+	withCacheEnabled(t)
+	filter := &ResponseCacheFilter{}
+	opts := &api.HandlerOptions{CacheTTL: time.Minute}
+
+	calls := map[string]int{}
+	next := func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		calls[r.URL.Path]++
+		_, _ = w.Write([]byte("ok"))
+	}
+	a := filter.ApplyFilter(string(api.GET), "/a", opts, next)
+	b := filter.ApplyFilter(string(api.GET), "/b", opts, next)
+
+	a(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/a", nil), nil) // miss a
+	a(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/a", nil), nil) // hit a
+	b(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/b", nil), nil) // miss b
+	if calls["/a"] != 1 || calls["/b"] != 1 {
+		t.Fatalf("setup: calls=%v", calls)
+	}
+
+	removed := InvalidatePath(string(api.GET), "/a")
+	if removed != 1 {
+		t.Fatalf("InvalidatePath(/a) removed %d, want 1", removed)
+	}
+
+	a(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/a", nil), nil) // miss a (purged)
+	b(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/b", nil), nil) // hit b (untouched)
+	if calls["/a"] != 2 || calls["/b"] != 1 {
+		t.Fatalf("after purge: calls=%v (want /a=2, /b=1)", calls)
+	}
+}


### PR DESCRIPTION
Split out from the easysearch/sqlite working branch so it can be reviewed and merged independently.

## Changes
- `core/api/options.go`: add a `Cache` option to the API options.
- `modules/security/http_filters/response_cache.go`: add `ResponseCacheFilter`, an HTTP filter that caches responses.
- `modules/security/http_filters/response_cache_test.go`: tests for the filter.

## Notes
- Based on `main` (`b969cf47`); self-contained, no dependency on the sqlite/modernc work.
- Build verified: `go build ./core/api/... ./modules/security/http_filters/...`