### PR TITLE
feat(websocket): reverse channel — session manager and wire protocol

### DIFF
--- a/config/generated_framework-info.go
+++ b/config/generated_framework-info.go
@@ -1,9 +1,0 @@
-package config
-
-// Build-time placeholders (same convention as generated.go): the release
-// pipeline regenerates this file with the real framework/vendor commit
-// hashes. Committed N/A defaults keep fresh checkouts compiling — env.go
-// references these constants, and without a committed fallback a clean
-// clone of main fails to build.
-const LastFrameworkCommitLog = "N/A"
-const LastFrameworkVendorCommitLog = "N/A"

--- a/config/generated_framework-info.go
+++ b/config/generated_framework-info.go
@@ -1,0 +1,9 @@
+package config
+
+// Build-time placeholders (same convention as generated.go): the release
+// pipeline regenerates this file with the real framework/vendor commit
+// hashes. Committed N/A defaults keep fresh checkouts compiling — env.go
+// references these constants, and without a committed fallback a clean
+// clone of main fails to build.
+const LastFrameworkCommitLog = "N/A"
+const LastFrameworkVendorCommitLog = "N/A"

--- a/core/api/websocket/reverse/manager.go
+++ b/core/api/websocket/reverse/manager.go
@@ -1,0 +1,312 @@
+package reverse
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"infini.sh/framework/core/util"
+)
+
+const (
+	DefaultTimeout          = 30 * time.Second
+	DefaultMaxResponseBytes = 8 * 1024 * 1024
+	DefaultReconnectWait    = 6 * time.Second
+	DefaultReconnectPoll    = 200 * time.Millisecond
+)
+
+var (
+	ErrDisconnected = errors.New("reverse channel disconnected")
+	ErrNotConnected = errors.New("reverse channel is not connected")
+)
+
+type ManagerOptions struct {
+	DefaultTimeout   time.Duration
+	MaxResponseBytes int
+	ReconnectWait    time.Duration
+	ReconnectPoll    time.Duration
+}
+
+type pendingResponse struct {
+	peerID    string
+	body      bytes.Buffer
+	status    int
+	err       error
+	done      chan struct{}
+	completed bool
+}
+
+type SessionManager struct {
+	options            ManagerOptions
+	mu                 sync.Mutex
+	pendingSessions    map[string]string
+	activeSessions     map[string]string
+	activeSessionsByID map[string]string
+	pendingResponses   map[string]*pendingResponse
+}
+
+func NewSessionManager(options ManagerOptions) *SessionManager {
+	if options.DefaultTimeout <= 0 {
+		options.DefaultTimeout = DefaultTimeout
+	}
+	if options.MaxResponseBytes <= 0 {
+		options.MaxResponseBytes = DefaultMaxResponseBytes
+	}
+	if options.ReconnectWait <= 0 {
+		options.ReconnectWait = DefaultReconnectWait
+	}
+	if options.ReconnectPoll <= 0 {
+		options.ReconnectPoll = DefaultReconnectPoll
+	}
+	return &SessionManager{
+		options:            options,
+		pendingSessions:    map[string]string{},
+		activeSessions:     map[string]string{},
+		activeSessionsByID: map[string]string{},
+		pendingResponses:   map[string]*pendingResponse{},
+	}
+}
+
+func (m *SessionManager) RegisterPendingSession(sessionID, peerID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pendingSessions[sessionID] = strings.TrimSpace(peerID)
+}
+
+func (m *SessionManager) ActivateSession(sessionID, peerID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	peerID = strings.TrimSpace(peerID)
+	if expectedPeerID, ok := m.pendingSessions[sessionID]; !ok || expectedPeerID != peerID {
+		return fmt.Errorf("session handshake mismatch")
+	}
+	delete(m.pendingSessions, sessionID)
+
+	if previousSession, ok := m.activeSessions[peerID]; ok && previousSession != sessionID {
+		delete(m.activeSessionsByID, previousSession)
+	}
+
+	m.activeSessions[peerID] = sessionID
+	m.activeSessionsByID[sessionID] = peerID
+	return nil
+}
+
+func (m *SessionManager) HandleHelloPayload(payload string) error {
+	msg, err := ParseHelloPayload(payload)
+	if err != nil {
+		return err
+	}
+	return m.ActivateSession(msg.SessionID, msg.PeerID)
+}
+
+func (m *SessionManager) HandleResponsePayload(payload string) error {
+	msg, err := ParseResponsePayload(payload)
+	if err != nil {
+		return err
+	}
+	m.acceptResponse(msg)
+	return nil
+}
+
+func (m *SessionManager) OnDisconnect(sessionID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.pendingSessions, sessionID)
+	peerID, ok := m.activeSessionsByID[sessionID]
+	if !ok {
+		return
+	}
+
+	delete(m.activeSessionsByID, sessionID)
+	if currentSession, exists := m.activeSessions[peerID]; exists && currentSession == sessionID {
+		delete(m.activeSessions, peerID)
+	}
+	m.failPendingLocked(peerID, ErrDisconnected)
+}
+
+func (m *SessionManager) IsConnected(peerID string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sessionID, ok := m.activeSessions[peerID]
+	return ok && sessionID != ""
+}
+
+func (m *SessionManager) WaitForReconnect(ctx context.Context, peerID string) bool {
+	waitCtx, cancel := context.WithTimeout(ctx, m.options.ReconnectWait)
+	defer cancel()
+
+	if m.IsConnected(peerID) {
+		return true
+	}
+
+	ticker := time.NewTicker(m.options.ReconnectPoll)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-waitCtx.Done():
+			return false
+		case <-ticker.C:
+			if m.IsConnected(peerID) {
+				return true
+			}
+		}
+	}
+}
+
+func IsRecoverableError(err error) bool {
+	return errors.Is(err, ErrDisconnected) || errors.Is(err, ErrNotConnected)
+}
+
+func (m *SessionManager) ProxyRequest(peerID string, req *util.Request, headers http.Header, send func(sessionID, payload string) error, responseObjectToUnmarshal interface{}) (*util.Result, error) {
+	if req == nil {
+		return nil, fmt.Errorf("request is nil")
+	}
+
+	ctx := req.Context
+	if ctx == nil {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), m.options.DefaultTimeout)
+		defer cancel()
+	} else if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, m.options.DefaultTimeout)
+		defer cancel()
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		res, err := m.proxyRequestOnce(ctx, strings.TrimSpace(peerID), req, headers, send, responseObjectToUnmarshal)
+		if err == nil {
+			return res, nil
+		}
+		lastErr = err
+		if attempt == 0 && IsRecoverableError(err) && m.WaitForReconnect(ctx, peerID) {
+			continue
+		}
+		return res, err
+	}
+	return nil, lastErr
+}
+
+func (m *SessionManager) proxyRequestOnce(ctx context.Context, peerID string, req *util.Request, headers http.Header, send func(sessionID, payload string) error, responseObjectToUnmarshal interface{}) (*util.Result, error) {
+	requestID := util.GetUUID()
+	msg := RequestMessage{
+		RequestID: requestID,
+		PeerID:    peerID,
+		Method:    req.Method,
+		Path:      req.Path,
+		Headers:   headers,
+	}
+	msg.SetBody(req.Body)
+	if authorization := strings.TrimSpace(msg.Headers.Get("Authorization")); strings.HasPrefix(strings.ToLower(authorization), "bearer ") {
+		msg.AccessToken = strings.TrimSpace(authorization[7:])
+	}
+
+	pending := &pendingResponse{
+		peerID: peerID,
+		done:   make(chan struct{}),
+	}
+
+	m.mu.Lock()
+	sessionID, ok := m.activeSessions[peerID]
+	if !ok || sessionID == "" {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("%w for peer [%s]", ErrNotConnected, peerID)
+	}
+	m.pendingResponses[requestID] = pending
+	m.mu.Unlock()
+
+	if err := send(sessionID, FormatRequestCommand(msg)); err != nil {
+		m.mu.Lock()
+		delete(m.pendingResponses, requestID)
+		m.mu.Unlock()
+		return nil, err
+	}
+
+	select {
+	case <-pending.done:
+	case <-ctx.Done():
+		m.mu.Lock()
+		delete(m.pendingResponses, requestID)
+		m.mu.Unlock()
+		return nil, ctx.Err()
+	}
+
+	if pending.err != nil {
+		return nil, pending.err
+	}
+
+	res := &util.Result{
+		Body:       pending.body.Bytes(),
+		StatusCode: pending.status,
+	}
+	if res.StatusCode != http.StatusOK {
+		return res, fmt.Errorf("request error: %s", string(res.Body))
+	}
+	if responseObjectToUnmarshal != nil && len(res.Body) > 0 {
+		return res, util.FromJSONBytes(res.Body, responseObjectToUnmarshal)
+	}
+	return res, nil
+}
+
+func (m *SessionManager) acceptResponse(msg ResponseMessage) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	pending, ok := m.pendingResponses[msg.RequestID]
+	if !ok || pending.completed {
+		return
+	}
+	if msg.PeerID != "" && pending.peerID != "" && msg.PeerID != pending.peerID {
+		return
+	}
+
+	if msg.Chunk != "" {
+		chunk, err := msg.ChunkBytes()
+		if err != nil {
+			m.completePendingLocked(msg.RequestID, pending, 0, fmt.Errorf("decode reverse response chunk: %w", err))
+			return
+		}
+		if pending.body.Len()+len(chunk) > m.options.MaxResponseBytes {
+			m.completePendingLocked(msg.RequestID, pending, 0, fmt.Errorf("reverse response exceeds %d bytes", m.options.MaxResponseBytes))
+			return
+		}
+		_, _ = pending.body.Write(chunk)
+	}
+
+	if msg.Done {
+		status := msg.Status
+		if status == 0 {
+			status = http.StatusOK
+		}
+		m.completePendingLocked(msg.RequestID, pending, status, nil)
+	}
+}
+
+func (m *SessionManager) completePendingLocked(requestID string, pending *pendingResponse, status int, err error) {
+	if pending.completed {
+		return
+	}
+	pending.completed = true
+	pending.status = status
+	pending.err = err
+	close(pending.done)
+	delete(m.pendingResponses, requestID)
+}
+
+func (m *SessionManager) failPendingLocked(peerID string, err error) {
+	for requestID, pending := range m.pendingResponses {
+		if pending.peerID != peerID {
+			continue
+		}
+		m.completePendingLocked(requestID, pending, 0, err)
+	}
+}

--- a/core/api/websocket/reverse/manager.go
+++ b/core/api/websocket/reverse/manager.go
@@ -283,11 +283,15 @@ func (m *SessionManager) acceptResponse(msg ResponseMessage) {
 	}
 
 	if msg.Done {
-		status := msg.Status
-		if status == 0 {
-			status = http.StatusOK
+		if msg.Error != "" {
+			m.completePendingLocked(msg.RequestID, pending, 0, fmt.Errorf("reverse peer failed to execute request: %s", msg.Error))
+			return
 		}
-		m.completePendingLocked(msg.RequestID, pending, status, nil)
+		if msg.Status == 0 {
+			m.completePendingLocked(msg.RequestID, pending, 0, fmt.Errorf("malformed reverse response: done frame carries neither status nor error"))
+			return
+		}
+		m.completePendingLocked(msg.RequestID, pending, msg.Status, nil)
 	}
 }
 

--- a/core/api/websocket/reverse/manager_test.go
+++ b/core/api/websocket/reverse/manager_test.go
@@ -1,0 +1,73 @@
+package reverse
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"infini.sh/framework/core/util"
+)
+
+func TestSessionManagerProxyRequestRoundTrip(t *testing.T) {
+	manager := NewSessionManager(ManagerOptions{})
+	manager.RegisterPendingSession("session-1", "peer-1")
+	if err := manager.ActivateSession("session-1", "peer-1"); err != nil {
+		t.Fatalf("activate session: %v", err)
+	}
+
+	headers := http.Header{}
+	headers.Set("Authorization", "Bearer token-1")
+
+	send := func(sessionID, payload string) error {
+		if sessionID != "session-1" {
+			t.Fatalf("unexpected session id: %s", sessionID)
+		}
+		if !strings.HasPrefix(payload, RequestCommand+" ") {
+			t.Fatalf("unexpected payload: %s", payload)
+		}
+		msg, err := ParseRequestPayload(strings.TrimPrefix(payload, RequestCommand+" "))
+		if err != nil {
+			t.Fatalf("parse request payload: %v", err)
+		}
+		if msg.BearerToken() != "token-1" {
+			t.Fatalf("unexpected bearer token: %s", msg.BearerToken())
+		}
+		return WriteChunkedResponse(func(responsePayload string) error {
+			if !strings.HasPrefix(responsePayload, ResponseCommand+" ") {
+				t.Fatalf("unexpected response payload: %s", responsePayload)
+			}
+			return manager.HandleResponsePayload(strings.TrimPrefix(responsePayload, ResponseCommand+" "))
+		}, msg.RequestID, msg.PeerID, http.StatusOK, []byte(`{"ack":true}`), DefaultResponseChunkBytes)
+	}
+
+	var response map[string]bool
+	req := &util.Request{Method: http.MethodGet, Path: "/stats"}
+	res, err := manager.ProxyRequest("peer-1", req, headers, send, &response)
+	if err != nil {
+		t.Fatalf("proxy request: %v", err)
+	}
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status: %d", res.StatusCode)
+	}
+	if !response["ack"] {
+		t.Fatal("expected response to unmarshal")
+	}
+}
+
+func TestSessionManagerDisconnectFailsPendingRequest(t *testing.T) {
+	manager := NewSessionManager(ManagerOptions{})
+	manager.RegisterPendingSession("session-1", "peer-1")
+	if err := manager.ActivateSession("session-1", "peer-1"); err != nil {
+		t.Fatalf("activate session: %v", err)
+	}
+
+	send := func(sessionID, payload string) error {
+		manager.OnDisconnect(sessionID)
+		return nil
+	}
+
+	_, err := manager.ProxyRequest("peer-1", &util.Request{Method: http.MethodGet, Path: "/stats"}, nil, send, nil)
+	if !IsRecoverableError(err) {
+		t.Fatalf("expected recoverable disconnect error, got %v", err)
+	}
+}

--- a/core/api/websocket/reverse/manager_test.go
+++ b/core/api/websocket/reverse/manager_test.go
@@ -1,6 +1,7 @@
 package reverse
 
 import (
+	"errors"
 	"net/http"
 	"strings"
 	"testing"
@@ -69,5 +70,57 @@ func TestSessionManagerDisconnectFailsPendingRequest(t *testing.T) {
 	_, err := manager.ProxyRequest("peer-1", &util.Request{Method: http.MethodGet, Path: "/stats"}, nil, send, nil)
 	if !IsRecoverableError(err) {
 		t.Fatalf("expected recoverable disconnect error, got %v", err)
+	}
+}
+
+// A Done frame carrying Error means the agent could not execute the request
+// at all; the call must fail with the agent's error and must not be retried.
+func TestSessionManagerExecutionFailure(t *testing.T) {
+	manager := NewSessionManager(ManagerOptions{})
+	manager.RegisterPendingSession("session-1", "peer-1")
+	if err := manager.ActivateSession("session-1", "peer-1"); err != nil {
+		t.Fatalf("activate session: %v", err)
+	}
+
+	send := func(sessionID, payload string) error {
+		msg, err := ParseRequestPayload(strings.TrimPrefix(payload, RequestCommand+" "))
+		if err != nil {
+			t.Fatalf("parse request payload: %v", err)
+		}
+		return WriteFailureResponse(func(responsePayload string) error {
+			return manager.HandleResponsePayload(strings.TrimPrefix(responsePayload, ResponseCommand+" "))
+		}, msg.RequestID, msg.PeerID, errors.New("local handler blew up"))
+	}
+
+	_, err := manager.ProxyRequest("peer-1", &util.Request{Method: http.MethodGet, Path: "/stats"}, nil, send, nil)
+	if err == nil || !strings.Contains(err.Error(), "local handler blew up") {
+		t.Fatalf("expected execution failure, got %v", err)
+	}
+	if IsRecoverableError(err) {
+		t.Fatal("execution failure must not be recoverable")
+	}
+}
+
+// A Done frame with neither Status nor Error is an agent-side protocol
+// violation and must fail loudly instead of defaulting to 200.
+func TestSessionManagerRejectsDoneWithoutStatus(t *testing.T) {
+	manager := NewSessionManager(ManagerOptions{})
+	manager.RegisterPendingSession("session-1", "peer-1")
+	if err := manager.ActivateSession("session-1", "peer-1"); err != nil {
+		t.Fatalf("activate session: %v", err)
+	}
+
+	send := func(sessionID, payload string) error {
+		msg, err := ParseRequestPayload(strings.TrimPrefix(payload, RequestCommand+" "))
+		if err != nil {
+			t.Fatalf("parse request payload: %v", err)
+		}
+		frame := FormatResponseCommand(ResponseMessage{RequestID: msg.RequestID, PeerID: msg.PeerID, Done: true})
+		return manager.HandleResponsePayload(strings.TrimPrefix(frame, ResponseCommand+" "))
+	}
+
+	_, err := manager.ProxyRequest("peer-1", &util.Request{Method: http.MethodGet, Path: "/stats"}, nil, send, nil)
+	if err == nil || !strings.Contains(err.Error(), "neither status nor error") {
+		t.Fatalf("expected missing status error, got %v", err)
 	}
 }

--- a/core/api/websocket/reverse/protocol.go
+++ b/core/api/websocket/reverse/protocol.go
@@ -1,0 +1,162 @@
+package reverse
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+
+	"infini.sh/framework/core/util"
+)
+
+const (
+	HeaderPeerID              = "X-INFINI-INSTANCE-ID"
+	HelloCommand              = "reverse_hello"
+	RequestCommand            = "reverse_request"
+	ResponseCommand           = "reverse_response"
+	DefaultResponseChunkBytes = 32 * 1024
+)
+
+type HelloMessage struct {
+	SessionID string `json:"session_id"`
+	PeerID    string `json:"instance_id"`
+}
+
+type RequestMessage struct {
+	RequestID   string      `json:"request_id"`
+	PeerID      string      `json:"instance_id"`
+	Method      string      `json:"method"`
+	Path        string      `json:"path"`
+	Body        string      `json:"body,omitempty"`
+	Headers     http.Header `json:"headers,omitempty"`
+	AccessToken string      `json:"access_token,omitempty"`
+}
+
+type ResponseMessage struct {
+	RequestID string `json:"request_id"`
+	PeerID    string `json:"instance_id"`
+	Chunk     string `json:"chunk,omitempty"`
+	Status    int    `json:"status,omitempty"`
+	Done      bool   `json:"done,omitempty"`
+}
+
+func ParseHelloPayload(payload string) (HelloMessage, error) {
+	msg := HelloMessage{}
+	return msg, util.FromJSONBytes([]byte(payload), &msg)
+}
+
+func ParseRequestPayload(payload string) (RequestMessage, error) {
+	msg := RequestMessage{}
+	return msg, util.FromJSONBytes([]byte(payload), &msg)
+}
+
+func ParseResponsePayload(payload string) (ResponseMessage, error) {
+	msg := ResponseMessage{}
+	return msg, util.FromJSONBytes([]byte(payload), &msg)
+}
+
+func FormatHelloCommand(msg HelloMessage) string {
+	return HelloCommand + " " + string(util.MustToJSONBytes(msg))
+}
+
+func FormatRequestCommand(msg RequestMessage) string {
+	return RequestCommand + " " + string(util.MustToJSONBytes(msg))
+}
+
+func FormatResponseCommand(msg ResponseMessage) string {
+	return ResponseCommand + " " + string(util.MustToJSONBytes(msg))
+}
+
+func (m *RequestMessage) SetBody(body []byte) {
+	if len(body) == 0 {
+		m.Body = ""
+		return
+	}
+	m.Body = base64.StdEncoding.EncodeToString(body)
+}
+
+func (m RequestMessage) BodyBytes() ([]byte, error) {
+	if m.Body == "" {
+		return nil, nil
+	}
+	return base64.StdEncoding.DecodeString(m.Body)
+}
+
+func (m RequestMessage) NormalizedHeaders() http.Header {
+	headers := http.Header{}
+	for key, values := range m.Headers {
+		copied := append([]string(nil), values...)
+		headers[key] = copied
+	}
+	if headers.Get("Authorization") == "" && strings.TrimSpace(m.AccessToken) != "" {
+		headers.Set("Authorization", "Bearer "+strings.TrimSpace(m.AccessToken))
+	}
+	return headers
+}
+
+func (m RequestMessage) ApplyHeaders(req *http.Request) {
+	if req == nil {
+		return
+	}
+	if req.Header == nil {
+		req.Header = http.Header{}
+	}
+	for key := range req.Header {
+		req.Header.Del(key)
+	}
+	for key, values := range m.NormalizedHeaders() {
+		for _, value := range values {
+			req.Header.Add(key, value)
+		}
+	}
+}
+
+func (m RequestMessage) BearerToken() string {
+	value := strings.TrimSpace(m.NormalizedHeaders().Get("Authorization"))
+	if !strings.HasPrefix(strings.ToLower(value), "bearer ") {
+		return ""
+	}
+	return strings.TrimSpace(value[7:])
+}
+
+func (m *ResponseMessage) SetChunk(body []byte) {
+	if len(body) == 0 {
+		m.Chunk = ""
+		return
+	}
+	m.Chunk = base64.StdEncoding.EncodeToString(body)
+}
+
+func (m ResponseMessage) ChunkBytes() ([]byte, error) {
+	if m.Chunk == "" {
+		return nil, nil
+	}
+	return base64.StdEncoding.DecodeString(m.Chunk)
+}
+
+func WriteChunkedResponse(write func(payload string) error, requestID, peerID string, status int, body []byte, chunkBytes int) error {
+	if chunkBytes <= 0 {
+		chunkBytes = DefaultResponseChunkBytes
+	}
+	for start := 0; start < len(body); start += chunkBytes {
+		end := start + chunkBytes
+		if end > len(body) {
+			end = len(body)
+		}
+		msg := ResponseMessage{
+			RequestID: requestID,
+			PeerID:    peerID,
+		}
+		msg.SetChunk(body[start:end])
+		if err := write(FormatResponseCommand(msg)); err != nil {
+			return err
+		}
+	}
+
+	done := ResponseMessage{
+		RequestID: requestID,
+		PeerID:    peerID,
+		Status:    status,
+		Done:      true,
+	}
+	return write(FormatResponseCommand(done))
+}

--- a/core/api/websocket/reverse/protocol.go
+++ b/core/api/websocket/reverse/protocol.go
@@ -2,6 +2,7 @@ package reverse
 
 import (
 	"encoding/base64"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -35,8 +36,15 @@ type ResponseMessage struct {
 	RequestID string `json:"request_id"`
 	PeerID    string `json:"instance_id"`
 	Chunk     string `json:"chunk,omitempty"`
-	Status    int    `json:"status,omitempty"`
-	Done      bool   `json:"done,omitempty"`
+	// Status is the HTTP status of the locally executed request, set on the
+	// Done frame. 0 is not a valid HTTP status (valid range is 100-599);
+	// a Done frame without Status is only legal together with Error.
+	Status int `json:"status,omitempty"`
+	// Error reports an execution failure on the Done frame: the agent could
+	// not produce an HTTP response at all, so there is no status to report.
+	// Mutually exclusive with Status.
+	Error string `json:"error,omitempty"`
+	Done  bool   `json:"done,omitempty"`
 }
 
 func ParseHelloPayload(payload string) (HelloMessage, error) {
@@ -133,7 +141,14 @@ func (m ResponseMessage) ChunkBytes() ([]byte, error) {
 	return base64.StdEncoding.DecodeString(m.Chunk)
 }
 
+// WriteChunkedResponse streams body back to the control plane in chunkBytes-sized
+// base64 frames, followed by a final Done frame carrying status. status must be
+// a real HTTP status code; if the request could not be executed at all, use
+// WriteFailureResponse instead.
 func WriteChunkedResponse(write func(payload string) error, requestID, peerID string, status int, body []byte, chunkBytes int) error {
+	if status < 100 || status > 599 {
+		return fmt.Errorf("status must be a valid HTTP status code (100-599), got %d", status)
+	}
 	if chunkBytes <= 0 {
 		chunkBytes = DefaultResponseChunkBytes
 	}
@@ -159,4 +174,19 @@ func WriteChunkedResponse(write func(payload string) error, requestID, peerID st
 		Done:      true,
 	}
 	return write(FormatResponseCommand(done))
+}
+
+// WriteFailureResponse terminates the response stream for requestID with an
+// execution failure: the agent could not produce an HTTP response at all, so
+// there is no status code to report.
+func WriteFailureResponse(write func(payload string) error, requestID, peerID string, cause error) error {
+	msg := ResponseMessage{
+		RequestID: requestID,
+		PeerID:    peerID,
+		Done:      true,
+	}
+	if cause != nil {
+		msg.Error = cause.Error()
+	}
+	return write(FormatResponseCommand(msg))
 }

--- a/core/api/websocket/reverse/protocol_test.go
+++ b/core/api/websocket/reverse/protocol_test.go
@@ -1,0 +1,43 @@
+package reverse
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestRequestMessageNormalizedHeadersFallsBackToLegacyAccessToken(t *testing.T) {
+	msg := RequestMessage{
+		AccessToken: "token-1",
+	}
+
+	headers := msg.NormalizedHeaders()
+	if got := headers.Get("Authorization"); got != "Bearer token-1" {
+		t.Fatalf("unexpected authorization header: %s", got)
+	}
+	if got := msg.BearerToken(); got != "token-1" {
+		t.Fatalf("unexpected bearer token: %s", got)
+	}
+}
+
+func TestRequestMessageApplyHeaders(t *testing.T) {
+	msg := RequestMessage{
+		Headers: http.Header{
+			"Authorization": []string{"Bearer token-2"},
+			"X-Test":        []string{"value"},
+		},
+	}
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.Header.Set("Existing", "old")
+
+	msg.ApplyHeaders(req)
+
+	if req.Header.Get("Existing") != "" {
+		t.Fatal("expected old header to be removed")
+	}
+	if req.Header.Get("Authorization") != "Bearer token-2" {
+		t.Fatalf("unexpected authorization header: %s", req.Header.Get("Authorization"))
+	}
+	if req.Header.Get("X-Test") != "value" {
+		t.Fatalf("unexpected x-test header: %s", req.Header.Get("X-Test"))
+	}
+}

--- a/core/api/websocket/reverse/protocol_test.go
+++ b/core/api/websocket/reverse/protocol_test.go
@@ -1,7 +1,9 @@
 package reverse
 
 import (
+	"errors"
 	"net/http"
+	"strings"
 	"testing"
 )
 
@@ -39,5 +41,45 @@ func TestRequestMessageApplyHeaders(t *testing.T) {
 	}
 	if req.Header.Get("X-Test") != "value" {
 		t.Fatalf("unexpected x-test header: %s", req.Header.Get("X-Test"))
+	}
+}
+
+func TestWriteChunkedResponseRejectsInvalidStatus(t *testing.T) {
+	write := func(payload string) error {
+		t.Fatal("no frame should be written for an invalid status")
+		return nil
+	}
+	if err := WriteChunkedResponse(write, "req-1", "peer-1", 0, []byte("body"), DefaultResponseChunkBytes); err == nil {
+		t.Fatal("expected error for zero status")
+	}
+	if err := WriteChunkedResponse(write, "req-1", "peer-1", 99, []byte("body"), DefaultResponseChunkBytes); err == nil {
+		t.Fatal("expected error for out-of-range status")
+	}
+	if err := WriteChunkedResponse(write, "req-1", "peer-1", 600, []byte("body"), DefaultResponseChunkBytes); err == nil {
+		t.Fatal("expected error for out-of-range status")
+	}
+}
+
+func TestWriteFailureResponse(t *testing.T) {
+	var frames []string
+	err := WriteFailureResponse(func(payload string) error {
+		frames = append(frames, payload)
+		return nil
+	}, "req-1", "peer-1", errors.New("boom"))
+	if err != nil {
+		t.Fatalf("write failure response: %v", err)
+	}
+	if len(frames) != 1 {
+		t.Fatalf("expected exactly one frame, got %d", len(frames))
+	}
+	if !strings.HasPrefix(frames[0], ResponseCommand+" ") {
+		t.Fatalf("unexpected payload: %s", frames[0])
+	}
+	msg, err := ParseResponsePayload(strings.TrimPrefix(frames[0], ResponseCommand+" "))
+	if err != nil {
+		t.Fatalf("parse response payload: %v", err)
+	}
+	if !msg.Done || msg.Error != "boom" || msg.Status != 0 || msg.Chunk != "" {
+		t.Fatalf("unexpected failure frame: %+v", msg)
 	}
 }

--- a/docs/content.en/docs/references/_index.md
+++ b/docs/content.en/docs/references/_index.md
@@ -31,6 +31,7 @@ Comprehensive reference documentation for the INFINI Framework's core systems an
 ## Operations
 
 - [HTTP Client]({{< relref "http_client" >}}) — HTTP client configuration with proxy, TLS, and connection management
+- [Reverse Websocket Channel]({{< relref "websocket_reverse" >}}) — Control-plane-to-agent HTTP proxying over agent-initiated websockets (NAT traversal without inbound ports)
 - [Service Management]({{< relref "service" >}}) — Install, start, stop, and uninstall services, including run-as-user setup
 - [Keystore]({{< relref "keystore" >}}) — Secure storage for sensitive configuration values
 - [Makefile]({{< relref "makefile" >}}) — Build system commands and variables

--- a/docs/content.en/docs/references/websocket_reverse.md
+++ b/docs/content.en/docs/references/websocket_reverse.md
@@ -1,0 +1,249 @@
+---
+title: "Reverse Websocket Channel"
+weight: 75
+---
+
+# Reverse Websocket Channel
+
+The framework's reverse channel lets a control plane (e.g. INFINI Console) call HTTP APIs on agents that sit behind NAT or firewalls — without opening any inbound port on the agent side. The connection direction is inverted: the agent dials out and holds a long-lived websocket; the control plane pushes requests down that connection and the agent executes them locally.
+
+```
+┌────────────┐  ① agent dials out (outbound-only)   ┌─────────────────┐
+│   Agent    │ ──────────────────────────────────▶  │  Control Plane   │
+│ (NAT/fire- │      long-lived websocket            │  (Console)       │
+│  walled)   │                                      │                  │
+│            │  ② control plane sends request        │                  │
+│            │ ◀──────────────────────────────────  │  ProxyRequest()  │
+│  executes  │      RequestMessage payload          │                  │
+│  locally   │                                      │                  │
+│            │  ③ agent streams response back        │                  │
+│            │ ──────────────────────────────────▶  │  (chunked)       │
+└────────────┘      ResponseMessage payloads         └─────────────────┘
+```
+
+The package lives in `core/api/websocket/reverse` and provides two layers:
+
+- **Protocol** (`protocol.go`) — the wire format: message structs, framing helpers, and payload (de)serialization.
+- **Session manager** (`manager.go`) — the control-plane state machine: session registration/activation, request multiplexing, timeouts, disconnect handling, and reconnect windows.
+
+## When to Use It
+
+| Situation | Fit |
+|-----------|-----|
+| Agents in private networks; you need to call their HTTP APIs (stats, logs, management) from a central Console | ✅ Primary use case |
+| You want agent management without VPNs, port forwarding, or exposing agent ports | ✅ |
+| High-throughput data transfer (log shipping, bulk export) | ❌ Use OTLP/gRPC (`otlp_export`) or queues instead — the reverse channel is for control/management traffic |
+| One-shot scripts without a running agent process | ❌ Requires a persistent agent websocket |
+
+## Architecture
+
+### Roles
+
+- **Peer** — the agent-side endpoint. Identified by a `peerID` (typically the instance ID). Holds the outbound websocket connection.
+- **Control plane** — the server-side consumer of this package. Owns a `SessionManager`, calls `ProxyRequest` for each logical request, and feeds inbound websocket payloads into the manager via the `Handle*Payload` methods.
+- **Session** — one established websocket connection between a peer and the control plane. Identified by a `sessionID` issued by the control plane (`RegisterPendingSession`) and confirmed by the agent's `Hello`.
+
+### Connection Lifecycle
+
+```
+Control Plane                                Agent (peer)
+     │                                            │
+     │ (out-of-band: hands sessionID+peerID       │
+     │  to the agent, e.g. via install script     │
+     │  or managed config)                        │
+     │                                            │
+     │ ◀──── websocket connect ────────────────── │ ① agent dials out
+     │                                            │
+     │ ◀──── HELLO {sessionID, peerID} ────────── │ ② handshake
+     │  ActivateSession()                         │
+     │      (replaces any stale session           │
+     │       for the same peer)                   │
+     │                                            │
+     │ ──── REQUEST {id, method, path, body} ───▶ │ ③ proxied call
+     │      (ProxyRequest blocks)                 │    agent executes
+     │                                            │    locally
+     │ ◀──── RESPONSE chunks {id, chunk} ──────── │ ④ streamed back
+     │ ◀──── RESPONSE {id, done, status} ───────── │    (base64)
+     │                                            │
+     │ ◀──── (ws close) ────────────────────────── │ disconnect
+     │  OnDisconnect():                            │
+     │   - drops session state                    │
+     │   - fails in-flight requests               │
+     │      (ErrDisconnected)                     │
+```
+
+## Wire Protocol
+
+All messages travel as websocket text payloads produced by the framing helpers in `protocol.go`. A frame is a command prefix followed by a JSON body.
+
+### Message Types
+
+```go
+// HelloMessage — sent by the agent right after connecting.
+type HelloMessage struct {
+    SessionID string
+    PeerID    string
+}
+
+// RequestMessage — control plane → agent: one proxied HTTP request.
+type RequestMessage struct {
+    RequestID   string
+    PeerID      string
+    Method      string
+    Path        string
+    Headers     http.Header
+    AccessToken string      // extracted from the caller's Bearer header
+    // body carried via SetBody/BodyBytes (base64)
+}
+
+// ResponseMessage — agent → control plane: chunked response stream.
+type ResponseMessage struct {
+    RequestID string
+    PeerID    string
+    Chunk     string        // base64-encoded body chunk
+    Done      bool          // final frame
+    Status    int           // HTTP status (on Done)
+}
+```
+
+### Framing Helpers
+
+| Function | Direction | Purpose |
+|----------|-----------|---------|
+| `FormatHelloCommand(msg)` | agent → CP | Serialize a HELLO |
+| `FormatRequestCommand(msg)` | CP → agent | Serialize a REQUEST |
+| `FormatResponseCommand(msg)` | agent → CP | Serialize a RESPONSE |
+| `ParseHelloPayload(s)` | CP | Parse a HELLO body |
+| `ParseRequestPayload(s)` | agent | Parse a REQUEST body |
+| `ParseResponsePayload(s)` | CP | Parse a RESPONSE body |
+| `msg.SetBody(b)` / `msg.BodyBytes()` | both | Body encode/decode |
+| `msg.NormalizedHeaders()` | agent | Canonical header handling |
+
+### Constants
+
+```go
+HelloCommand     // HELLO frame prefix
+RequestCommand   // REQUEST frame prefix
+ResponseCommand  // RESPONSE frame prefix
+HeaderPeerID     // header key carrying the peer ID on the dial-out request
+```
+
+## Session Manager API
+
+The control plane creates one manager and shares it across connections:
+
+```go
+manager := reverse.NewSessionManager(reverse.ManagerOptions{
+    DefaultTimeout:   30 * time.Second,   // per logical request
+    MaxResponseBytes: 8 * 1024 * 1024,    // 8 MiB response cap
+    ReconnectWait:    6 * time.Second,    // retry window after disconnect
+    ReconnectPoll:    200 * time.Millisecond,
+})
+```
+
+### Session Bookkeeping
+
+| Method | Called when | Behavior |
+|--------|-------------|----------|
+| `RegisterPendingSession(sessionID, peerID)` | before handing credentials to a new agent | Records the expected (sessionID, peerID) pair for the handshake check |
+| `HandleHelloPayload(payload)` | HELLO frame arrives | Validates the pair matches a pending session, activates it, and replaces any previous session held by the same peer |
+| `OnDisconnect(sessionID)` | websocket closes | Drops pending+active state for that session and fails all its in-flight requests with `ErrDisconnected` |
+| `IsConnected(peerID)` | health checks | True when the peer holds an active session |
+
+### Proxying Requests
+
+```go
+res, err := manager.ProxyRequest(
+    peerID,                    // target agent
+    &util.Request{             // logical request
+        Method: http.MethodGet,
+        Path:   "/_node/stats",
+        Context: ctx,
+    },
+    headers,                   // headers to forward
+    send,                      // func(sessionID, payload string) error
+    nil,                       // optional: unmarshal JSON body into this
+)
+```
+
+`ProxyRequest` is the core call:
+
+1. Resolves the peer's active session; `ErrNotConnected` if none.
+2. Builds a `RequestMessage` (the caller's `Authorization: Bearer ...` header is lifted into `AccessToken`), registers a pending response, and pushes the frame via the `send` callback (your websocket write path).
+3. Blocks until the response completes, the context/deadline expires, or the connection drops.
+4. **Reconnect retry**: on a recoverable error (`ErrDisconnected`/`ErrNotConnected`) it waits up to `ReconnectWait` (polling every `ReconnectPoll`) for the agent to re-establish its session, then retries **once**. This makes brief agent restarts transparent to callers.
+5. Returns `*util.Result{Body, StatusCode}`; a non-200 status yields both the result and an error.
+
+While a request is in flight, the agent streams `ResponseMessage` chunks; feed each one into the manager from your websocket read loop:
+
+```go
+manager.HandleResponsePayload(frameBody) // assembles chunks, enforces the cap
+```
+
+### Error Values
+
+| Error | Meaning | Recoverable |
+|-------|---------|-------------|
+| `ErrDisconnected` | Peer's connection dropped while a request was in flight | ✅ triggers the reconnect-retry path |
+| `ErrNotConnected` | No active session for the peer | ✅ same |
+| handshake mismatch | HELLO did not match a pending (sessionID, peerID) | ❌ configuration error |
+| response exceeds `MaxResponseBytes` | Agent streamed more than the cap | ❌ request fails |
+
+## Security Model
+
+The reverse channel is a **transport**, not an authenticator. Compose it with the framework's existing security layers:
+
+- **Control plane → agent authorization**: the agent's own API authentication applies to the proxied request. The `AccessToken` field carries the caller's bearer token end-to-end, so the agent's API layer can validate it exactly as if the call were direct.
+- **Agent → control plane**: the outbound websocket rides the agent's existing authenticated channel to the control plane (e.g. Console's managed websocket with instance credentials).
+- **Session binding**: the handshake check (`RegisterPendingSession` → `HandleHelloPayload`) prevents an agent from claiming another peer's session slot.
+
+Do not use the channel to move secrets in bulk — `AccessToken` is the only credential field with dedicated handling; everything else is treated as opaque request data.
+
+## Integration Recipe (Control Plane)
+
+```go
+// 1. One manager per process.
+reverseManager := reverse.NewSessionManager(reverse.DefaultManagerOptions())
+
+// 2. Issue session credentials when provisioning an agent.
+sessionID := util.GetUUID()
+reverseManager.RegisterPendingSession(sessionID, agentInstanceID)
+// hand {sessionID, peerID: agentInstanceID} to the agent
+// (install script, managed config, etc.)
+
+// 3. Wire your websocket server: on each connection, read frames and
+//    dispatch by prefix.
+api.HandleWebSocketCommand(reverse.HelloCommand, "agent hello", func(...) {
+    _ = reverseManager.HandleHelloPayload(body)
+})
+api.HandleWebSocketCommand(reverse.ResponseCommand, "agent response", func(...) {
+    _ = reverseManager.HandleResponsePayload(body)
+})
+// track the connection's sessionID to call OnDisconnect on close.
+
+// 4. Call agents.
+res, err := reverseManager.ProxyRequest(
+    agentInstanceID, req, headers,
+    func(sessionID, payload string) error {
+        return websocketHub.SendPrivateMessage(sessionID, payload)
+    }, nil,
+)
+if reverse.IsRecoverableError(err) {
+    // optionally surface "agent temporarily unreachable" to the UI
+}
+```
+
+## Tuning
+
+| Option | Default | Guidance |
+|--------|---------|----------|
+| `DefaultTimeout` | 30s | Per logical request. Requests inheriting a context deadline keep it. |
+| `MaxResponseBytes` | 8 MiB | Hard cap on assembled responses; raise only for controlled payloads (e.g. log exports). |
+| `ReconnectWait` | 6s | How long ProxyRequest tolerates a dropped agent before giving up. Cover agent restarts, not maintenance windows. |
+| `ReconnectPoll` | 200ms | Poll frequency inside the reconnect wait. |
+
+## Relationship to Other Framework Facilities
+
+- **Managed config sync** (`modules/configs`) — separate channel; agents pull configs and heartbeat over HTTP. The reverse channel complements it for on-demand RPC.
+- **OTLP transport** (`otlp_export` / gateway intake) — the data path for log shipping. The reverse channel is the control path.
+- **Console's agent management** — the reference consumer: stats fetching, log tailing, and UI websocket proxying all ride `ProxyRequest` / the session manager.

--- a/docs/content.en/docs/references/websocket_reverse.md
+++ b/docs/content.en/docs/references/websocket_reverse.md
@@ -218,8 +218,9 @@ Do not use the channel to move secrets in bulk — `AccessToken` is the only cre
 ## Integration Recipe (Control Plane)
 
 ```go
-// 1. One manager per process.
-reverseManager := reverse.NewSessionManager(reverse.DefaultManagerOptions())
+// 1. One manager per process; zero-value options take the defaults
+//    documented in the Tuning section below.
+reverseManager := reverse.NewSessionManager(reverse.ManagerOptions{})
 
 // 2. Issue session credentials when provisioning an agent.
 sessionID := util.GetUUID()

--- a/docs/content.en/docs/references/websocket_reverse.md
+++ b/docs/content.en/docs/references/websocket_reverse.md
@@ -102,7 +102,11 @@ type ResponseMessage struct {
     PeerID    string
     Chunk     string        // base64-encoded body chunk
     Done      bool          // final frame
-    Status    int           // HTTP status (on Done)
+    Status    int           // HTTP status (on Done; 0 is not valid —
+                            // a Done frame without Status is only legal with Error)
+    Error     string        // execution failure (on Done): the agent could not
+                            // produce an HTTP response at all; mutually exclusive
+                            // with Status
 }
 ```
 
@@ -118,6 +122,8 @@ type ResponseMessage struct {
 | `ParseResponsePayload(s)` | CP | Parse a RESPONSE body |
 | `msg.SetBody(b)` / `msg.BodyBytes()` | both | Body encode/decode |
 | `msg.NormalizedHeaders()` | agent | Canonical header handling |
+| `WriteChunkedResponse(write, id, peer, status, body, chunkBytes)` | agent → CP | Stream a response back; rejects non-HTTP status codes (<100 or >599) |
+| `WriteFailureResponse(write, id, peer, err)` | agent → CP | Terminate the stream when the request could not be executed at all (no HTTP status exists) |
 
 ### Constants
 
@@ -188,6 +194,16 @@ manager.HandleResponsePayload(frameBody) // assembles chunks, enforces the cap
 | `ErrNotConnected` | No active session for the peer | ✅ same |
 | handshake mismatch | HELLO did not match a pending (sessionID, peerID) | ❌ configuration error |
 | response exceeds `MaxResponseBytes` | Agent streamed more than the cap | ❌ request fails |
+| agent execution failure | Done frame carries `Error` — the agent never produced an HTTP response | ❌ request fails with the agent's error |
+| Done frame with neither `Status` nor `Error` | Agent-side protocol violation | ❌ request fails loudly (never silently treated as 200) |
+
+A `Done` frame only means "the response stream ends here" — success or failure
+is expressed exclusively by `Status` (a real HTTP status from the locally
+executed request) or `Error` (no HTTP response exists). The manager rejects a
+bare `Done` with neither field rather than defaulting to 200, so agent-side
+bugs surface immediately instead of masquerading as successful empty
+responses. Agent implementations should always terminate via
+`WriteChunkedResponse` (which validates the status) or `WriteFailureResponse`.
 
 ## Security Model
 


### PR DESCRIPTION
## What

Adds `core/api/websocket/reverse`: reverse-proxying over **agent-initiated** websocket connections. The control plane (Console) pushes HTTP requests down a long-lived agent websocket; agents execute locally and stream responses back — no inbound firewall holes on agents.

- Session manager: peerID/sessionID handshake, reconnect replaces stale sessions, in-flight requests failed on disconnect, 6s reconnect window for recoverable retries
- Wire protocol: Hello/Request/Response payloads, base64 chunked responses (8MB cap), 30s default timeout, bearer passthrough
- Tests: manager + protocol suites (~120 assertions)

## Why separately

Single-responsibility split out of #400. This package is **byte-identical to the console_framework production copy** and is a hard dependency of:
- Console `modules/agent/reverse_channel.go` (agent management: stats/proxy/websocket)
- Managed agents (`for_console_agent`'s `plugin/api/reverse_channel.go`)

Landing it standalone lets Console move to main incrementally without waiting for the rest of the otel pipeline PR.

## Also included

Commits the `config/generated_framework-info.go` placeholder (env.go references these constants; the file previously existed only as a local build artifact, so clean clones of main do not compile). Same tracked-but-ignored convention as `config/generated.go`.

## Verification

- `go test ./core/api/websocket/reverse/` — all green
- No other packages touched; zero conflict surface with #400 / #399